### PR TITLE
Items

### DIFF
--- a/src/main/java/com/hikari/hellofx/App.java
+++ b/src/main/java/com/hikari/hellofx/App.java
@@ -5,8 +5,10 @@ import java.util.HashMap;
 
 import com.hikari.hellofx.base.BaseModel;
 import com.hikari.hellofx.base.IModelSubscriber;
+import com.hikari.hellofx.game.view.GameView;
 
 import javafx.application.Application;
+import javafx.application.Platform;
 import javafx.scene.Scene;
 import javafx.scene.layout.GridPane;
 import javafx.stage.Stage;
@@ -64,8 +66,10 @@ public class App extends Application implements IModelSubscriber {
 	public void modelChanged(BaseModel model) {
 		if (model instanceof AppModel amodel) {
 			if(amodel.isStopped()) {
+				log.info("being stopped");
 				try {
-					stop();
+					askGameToStop();
+					Platform.exit();
 				} catch (Exception e) {
 					//dont want to propagate  non-informative "throws exception" everywhere
 					//just for exiting program in the end anyways
@@ -77,6 +81,14 @@ public class App extends Application implements IModelSubscriber {
 		} else {
 			throw new IllegalArgumentException("wrong appmodel");
 		}
+	}
+
+	private void askGameToStop() {
+		/*
+		 * TODO potential leak again here? why app knows about specific view, 
+		 * and view pokes controller for stopping?
+		 */
+		((GameView)scenes.get(SceneClass.GAME).getRoot()).stopTheWorld();
 	}
 
 }

--- a/src/main/java/com/hikari/hellofx/App.java
+++ b/src/main/java/com/hikari/hellofx/App.java
@@ -26,8 +26,8 @@ public class App extends Application implements IModelSubscriber {
 	private static final Integer HEIGHT = 720;
 
 	@Override
-	public void start(Stage stage_) throws Exception {
-		stage = stage_;
+	public void start(Stage stage) throws Exception {
+		this.stage = stage;
 		stage.setTitle("fxtorio");
 		appModel.subscribe(this);
 
@@ -46,7 +46,7 @@ public class App extends Application implements IModelSubscriber {
 	 * Mandatory pairs Model + View Name + NameView
 	 */
 
-	private void prepareScenes() throws ClassNotFoundException, InstantiationException, IllegalAccessException,
+	private void prepareScenes() throws InstantiationException, IllegalAccessException,
 			IllegalArgumentException, InvocationTargetException, NoSuchMethodException, SecurityException {
 		for (SceneClass s : SceneClass.values()) {
 			GridPane newPane = s.getSceneClass().getDeclaredConstructor(SceneController.class)

--- a/src/main/java/com/hikari/hellofx/App.java
+++ b/src/main/java/com/hikari/hellofx/App.java
@@ -22,8 +22,9 @@ public class App extends Application implements IModelSubscriber {
 	private final AppModel appModel = new AppModel();
 	private final SceneController sceneController = new SceneController(appModel);
 	private final HashMap<SceneClass, Scene> scenes = new HashMap<>();
-	private static final Integer WIDTH = 1280;
-	private static final Integer HEIGHT = 720;
+	private static final Integer WIDTH = 1600;
+	private static final Integer HEIGHT = 900;
+	private static final int STOP_ERROR_CODE = -1;
 
 	@Override
 	public void start(Stage stage) throws Exception {
@@ -61,10 +62,21 @@ public class App extends Application implements IModelSubscriber {
 
 	@Override
 	public void modelChanged(BaseModel model) {
-		if (!(model instanceof AppModel)) {
+		if (model instanceof AppModel amodel) {
+			if(amodel.isStopped()) {
+				try {
+					stop();
+				} catch (Exception e) {
+					//dont want to propagate  non-informative "throws exception" everywhere
+					//just for exiting program in the end anyways
+					log.error("error while stopping", e);
+					System.exit(STOP_ERROR_CODE);
+				}
+			}
+			stage.setScene(scenes.get(appModel.getCurrentScene()));
+		} else {
 			throw new IllegalArgumentException("wrong appmodel");
 		}
-		stage.setScene(scenes.get(appModel.getCurrentScene()));
 	}
 
 }

--- a/src/main/java/com/hikari/hellofx/AppModel.java
+++ b/src/main/java/com/hikari/hellofx/AppModel.java
@@ -4,6 +4,7 @@ package com.hikari.hellofx;
 import com.hikari.hellofx.base.BaseModel;
 
 public class AppModel extends BaseModel {
+	private boolean isStopped = false;
 	private SceneClass currentSceneName = SceneClass.MENU;
 
 	public SceneClass getCurrentScene() {
@@ -13,6 +14,14 @@ public class AppModel extends BaseModel {
 	public void setCurrentScene(SceneClass nextSceneName) {
 		currentSceneName = nextSceneName;
 		super.notifySubs();
+	}
+	
+	public boolean isStopped() {
+		return isStopped;
+	}
+	
+	public void stop() {
+		isStopped = true;
 	}
 
 }

--- a/src/main/java/com/hikari/hellofx/AppModel.java
+++ b/src/main/java/com/hikari/hellofx/AppModel.java
@@ -6,9 +6,6 @@ import com.hikari.hellofx.base.BaseModel;
 public class AppModel extends BaseModel {
 	private SceneClass currentSceneName = SceneClass.MENU;
 
-	public AppModel() {
-	}
-
 	public SceneClass getCurrentScene() {
 		return currentSceneName;
 	}

--- a/src/main/java/com/hikari/hellofx/AppModel.java
+++ b/src/main/java/com/hikari/hellofx/AppModel.java
@@ -16,12 +16,13 @@ public class AppModel extends BaseModel {
 		super.notifySubs();
 	}
 	
-	public boolean isStopped() {
-		return isStopped;
+	public void setStopped() {
+		isStopped = true;
+		super.notifySubs();
 	}
 	
-	public void stop() {
-		isStopped = true;
+	public boolean isStopped() {
+		return isStopped;
 	}
 
 }

--- a/src/main/java/com/hikari/hellofx/MenuView.java
+++ b/src/main/java/com/hikari/hellofx/MenuView.java
@@ -1,5 +1,6 @@
 package com.hikari.hellofx;
 
+import com.hikari.hellofx.game.view.ExitButton;
 import com.hikari.hellofx.game.view.NavButton;
 
 import javafx.geometry.Insets;
@@ -20,7 +21,7 @@ public class MenuView extends GridPane{
 		add(new Button("New game"), 0, 1);
 		add(new Button("Load game"), 0, 2);
 		add(new Button("Credits"), 0, 3);
-		add(new Button("Exit"), 0, 4);
+		add(new ExitButton(controller, "Exit"), 0, 4);
 		
 	}
 }

--- a/src/main/java/com/hikari/hellofx/SceneController.java
+++ b/src/main/java/com/hikari/hellofx/SceneController.java
@@ -6,8 +6,8 @@ import lombok.extern.log4j.Log4j2;
 public class SceneController {
 	private final AppModel model;
 	
-	public SceneController(AppModel model_) {
-		model = model_;
+	public SceneController(AppModel model) {
+		this.model = model;
 	}
 	
 	public void changeCurrentScene(SceneClass nextSceneName){

--- a/src/main/java/com/hikari/hellofx/SceneController.java
+++ b/src/main/java/com/hikari/hellofx/SceneController.java
@@ -17,4 +17,8 @@ public class SceneController {
 			log.error("Error changing scene: ", e);
 		}
 	}
+	
+	public void exit() {
+		model.setStopped();
+	}
 }

--- a/src/main/java/com/hikari/hellofx/base/BaseService.java
+++ b/src/main/java/com/hikari/hellofx/base/BaseService.java
@@ -30,19 +30,18 @@ public abstract class BaseService extends Thread{
 	}
 	
 	public void safeStop() {
-		this.interrupt();
+		Thread.currentThread().interrupt();
 	}
 	
 	@Override
 	public void run() {
 		while (true) {
 			try {
-				while(!model.isOn()) {
-					selfWait();
-				}
+				selfWait();
 				performCycle();
 			} catch (InterruptedException e) {
 				log.error("Interrupted");
+				Thread.currentThread().interrupt();
 				return;
 				//TODO conditional variable? methods for safer stop/start/kill
 			}

--- a/src/main/java/com/hikari/hellofx/base/BaseService.java
+++ b/src/main/java/com/hikari/hellofx/base/BaseService.java
@@ -10,16 +10,24 @@ public abstract class BaseService extends Thread{
 	private final ISuspendable model;
 	@Getter
 	private final Object monitor = new Object();
+	private boolean hasItemsQueued = false;
 	
 	protected BaseService(ISuspendable model) {
 		this.model = model;
 	}
 	
+	public void armItemsQueued() {
+		synchronized(monitor) {
+			hasItemsQueued = true;
+		}
+	}
+	
 	protected void selfWait() throws InterruptedException {
 		synchronized(monitor) {
-			while(!model.isOn()) {
+			while(!hasItemsQueued || !model.isOn()) {
 				monitor.wait();
 			}
+			hasItemsQueued = false;
 		}
 	}
 	

--- a/src/main/java/com/hikari/hellofx/base/BaseService.java
+++ b/src/main/java/com/hikari/hellofx/base/BaseService.java
@@ -22,6 +22,10 @@ public abstract class BaseService extends Thread{
 		return model;
 	}
 	
+	public void safeStop() {
+		this.interrupt();
+	}
+	
 	@Override
 	public void run() {
 		while (true) {
@@ -32,7 +36,8 @@ public abstract class BaseService extends Thread{
 				performCycle();
 			} catch (InterruptedException e) {
 				log.error("Interrupted");
-				//TODO interrupt mb?
+				return;
+				//TODO conditional variable? methods for safer stop/start/kill
 			}
 		}
 	}

--- a/src/main/java/com/hikari/hellofx/base/BaseService.java
+++ b/src/main/java/com/hikari/hellofx/base/BaseService.java
@@ -30,7 +30,7 @@ public abstract class BaseService extends Thread{
 	}
 	
 	public void safeStop() {
-		Thread.currentThread().interrupt();
+		this.interrupt();
 	}
 	
 	@Override
@@ -41,7 +41,7 @@ public abstract class BaseService extends Thread{
 				performCycle();
 			} catch (InterruptedException e) {
 				log.error("Interrupted");
-				Thread.currentThread().interrupt();
+				this.interrupt();
 				return;
 				//TODO conditional variable? methods for safer stop/start/kill
 			}

--- a/src/main/java/com/hikari/hellofx/base/BaseService.java
+++ b/src/main/java/com/hikari/hellofx/base/BaseService.java
@@ -2,17 +2,24 @@ package com.hikari.hellofx.base;
 
 import com.hikari.hellofx.entity.ISuspendable;
 
-import lombok.RequiredArgsConstructor;
+import lombok.Getter;
 import lombok.extern.log4j.Log4j2;
 
 @Log4j2
-@RequiredArgsConstructor
 public abstract class BaseService extends Thread{
 	private final ISuspendable model;
+	@Getter
+	private final Object monitor = new Object();
+	
+	protected BaseService(ISuspendable model) {
+		this.model = model;
+	}
 	
 	protected void selfWait() throws InterruptedException {
-		synchronized(this) {
-			wait();
+		synchronized(monitor) {
+			while(!model.isOn()) {
+				monitor.wait();
+			}
 		}
 	}
 	

--- a/src/main/java/com/hikari/hellofx/entity/BindingController.java
+++ b/src/main/java/com/hikari/hellofx/entity/BindingController.java
@@ -2,7 +2,7 @@ package com.hikari.hellofx.entity;
 
 import com.hikari.hellofx.base.BaseModel;
 import com.hikari.hellofx.base.IModelSubscriber;
-import com.hikari.hellofx.entity.model.ConnectionPoint;
+import com.hikari.hellofx.entity.model.cpoint.ConnectionPoint;
 import com.hikari.hellofx.game.GameController;
 import com.hikari.hellofx.game.control.ControlTransferObject;
 

--- a/src/main/java/com/hikari/hellofx/entity/BindingController.java
+++ b/src/main/java/com/hikari/hellofx/entity/BindingController.java
@@ -3,10 +3,9 @@ package com.hikari.hellofx.entity;
 import com.hikari.hellofx.base.BaseModel;
 import com.hikari.hellofx.base.IModelSubscriber;
 import com.hikari.hellofx.entity.model.ConnectionPoint;
-import com.hikari.hellofx.game.GameAction;
 import com.hikari.hellofx.game.GameController;
+import com.hikari.hellofx.game.control.ControlTransferObject;
 
-import javafx.scene.input.MouseEvent;
 import lombok.AllArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 
@@ -20,14 +19,14 @@ public class BindingController{
 	private final GameController gController;
 	private final BaseModel model;
 	
-	public void handleClick(MouseEvent event, GameAction action) {
+	public void handleClick(ControlTransferObject cto) {
 		log.debug("noticing " + model.toString());
-		gController.notice(model, event, action);
+		gController.notice(cto, model);
 	}
 	
-	public void handleConnection(MouseEvent event, GameAction action, ConnectionPoint point) {
+	public void handleConnection(ControlTransferObject cto, ConnectionPoint point) {
 		log.debug("noticing " + point.toString());
-		gController.notice(point, event, action);
+		gController.notice(cto, point);
 	}
 	
 	public void breakBond(IModelSubscriber view) {

--- a/src/main/java/com/hikari/hellofx/entity/IConnectable.java
+++ b/src/main/java/com/hikari/hellofx/entity/IConnectable.java
@@ -5,11 +5,18 @@ import java.util.List;
 import com.hikari.hellofx.entity.model.ConnectableState;
 import com.hikari.hellofx.entity.model.ConnectionInPoint;
 import com.hikari.hellofx.entity.model.ConnectionOutPoint;
+import com.hikari.hellofx.entity.model.ConnectionPoint;
 
-public interface IConnectable extends ISuspendable{
+public interface IConnectable extends ISuspendable {
 	public ConnectableState getConnectableState();
+
 	public void setConnectableState(ConnectableState state_);
+
 	public List<ConnectionInPoint> getInPoints();
+
 	public List<ConnectionOutPoint> getOutPoints();
+
+	public List<ConnectionPoint> filterFreePoints(Class<? extends ConnectionPoint> point);
+
 	public Integer getFillCount();
 }

--- a/src/main/java/com/hikari/hellofx/entity/IConnectable.java
+++ b/src/main/java/com/hikari/hellofx/entity/IConnectable.java
@@ -3,14 +3,14 @@ package com.hikari.hellofx.entity;
 import java.util.List;
 
 import com.hikari.hellofx.entity.model.ConnectableState;
-import com.hikari.hellofx.entity.model.ConnectionInPoint;
-import com.hikari.hellofx.entity.model.ConnectionOutPoint;
-import com.hikari.hellofx.entity.model.ConnectionPoint;
+import com.hikari.hellofx.entity.model.cpoint.ConnectionInPoint;
+import com.hikari.hellofx.entity.model.cpoint.ConnectionOutPoint;
+import com.hikari.hellofx.entity.model.cpoint.ConnectionPoint;
 
 public interface IConnectable extends ISuspendable {
 	public ConnectableState getConnectableState();
 
-	public void setConnectableState(ConnectableState state_);
+	public void setConnectableState(ConnectableState state);
 
 	public List<ConnectionInPoint> getInPoints();
 

--- a/src/main/java/com/hikari/hellofx/entity/IConnectable.java
+++ b/src/main/java/com/hikari/hellofx/entity/IConnectable.java
@@ -18,5 +18,7 @@ public interface IConnectable extends ISuspendable {
 
 	public List<ConnectionPoint> filterFreePoints(Class<? extends ConnectionPoint> point);
 
+	public List<ConnectionPoint> filterNonFreePoints(Class<? extends ConnectionPoint> point);
+	
 	public Integer getFillCount();
 }

--- a/src/main/java/com/hikari/hellofx/entity/IConnection.java
+++ b/src/main/java/com/hikari/hellofx/entity/IConnection.java
@@ -1,7 +1,7 @@
 package com.hikari.hellofx.entity;
 
-import com.hikari.hellofx.entity.model.ConnectionInPoint;
-import com.hikari.hellofx.entity.model.ConnectionOutPoint;
+import com.hikari.hellofx.entity.model.cpoint.ConnectionInPoint;
+import com.hikari.hellofx.entity.model.cpoint.ConnectionOutPoint;
 
 public interface IConnection {
 	public void connectDestination(ConnectionInPoint o);

--- a/src/main/java/com/hikari/hellofx/entity/IConnection.java
+++ b/src/main/java/com/hikari/hellofx/entity/IConnection.java
@@ -6,4 +6,6 @@ import com.hikari.hellofx.entity.model.ConnectionOutPoint;
 public interface IConnection {
 	public void connectDestination(ConnectionInPoint o);
 	public void connectSource(ConnectionOutPoint o);
+	public void markDetached();
+	public boolean isDetached();
 }

--- a/src/main/java/com/hikari/hellofx/entity/IProducer.java
+++ b/src/main/java/com/hikari/hellofx/entity/IProducer.java
@@ -2,5 +2,5 @@ package com.hikari.hellofx.entity;
 
 public interface IProducer {
 	public Recipe getCurrentRecipe();
-	public void setCurrentRecipe(Items item);
+	public void setCurrentRecipe(Item item);
 }

--- a/src/main/java/com/hikari/hellofx/entity/IProducer.java
+++ b/src/main/java/com/hikari/hellofx/entity/IProducer.java
@@ -1,0 +1,6 @@
+package com.hikari.hellofx.entity;
+
+public interface IProducer {
+	public Recipe getCurrentRecipe();
+	public void setCurrentRecipe(Items item);
+}

--- a/src/main/java/com/hikari/hellofx/entity/IServiceNotifier.java
+++ b/src/main/java/com/hikari/hellofx/entity/IServiceNotifier.java
@@ -2,7 +2,7 @@ package com.hikari.hellofx.entity;
 
 import com.hikari.hellofx.base.BaseService;
 
-public interface IServiceable {
+public interface IServiceNotifier {
 	public void connectService(BaseService service);
 	public void disconnectService();
 	public void notifyService();

--- a/src/main/java/com/hikari/hellofx/entity/Item.java
+++ b/src/main/java/com/hikari/hellofx/entity/Item.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 public enum Item {
 	IRON(Color.SILVER, ""),
 	COPPER(Color.SANDYBROWN, ""),
+	POLYMER(Color.DARKBLUE, ""),
 	IRON_PLATE(Color.SILVER, "P"),
 	IRON_ROD(Color.SILVER, "R"),
 	SCREW(Color.SLATEBLUE, "S"),

--- a/src/main/java/com/hikari/hellofx/entity/Item.java
+++ b/src/main/java/com/hikari/hellofx/entity/Item.java
@@ -2,10 +2,10 @@ package com.hikari.hellofx.entity;
 
 import javafx.scene.paint.Color;
 import lombok.AllArgsConstructor;
-import lombok.Setter;
+import lombok.Getter;
 
 @AllArgsConstructor
-public enum Items {
+public enum Item {
 	IRON(Color.SILVER, ""),
 	COPPER(Color.SANDYBROWN, ""),
 	IRON_PLATE(Color.SILVER, "P"),
@@ -15,8 +15,8 @@ public enum Items {
 	CABLE(Color.TURQUOISE, "C"),
 	FRAME(Color.DARKCYAN, "F");
 	
-	@Setter
+	@Getter
 	private Color color;
-	@Setter
+	@Getter
 	private String tag;
 }

--- a/src/main/java/com/hikari/hellofx/entity/Items.java
+++ b/src/main/java/com/hikari/hellofx/entity/Items.java
@@ -1,0 +1,22 @@
+package com.hikari.hellofx.entity;
+
+import javafx.scene.paint.Color;
+import lombok.AllArgsConstructor;
+import lombok.Setter;
+
+@AllArgsConstructor
+public enum Items {
+	IRON(Color.SILVER, ""),
+	COPPER(Color.SANDYBROWN, ""),
+	IRON_PLATE(Color.SILVER, "P"),
+	IRON_ROD(Color.SILVER, "R"),
+	SCREW(Color.SLATEBLUE, "S"),
+	WIRE(Color.SANDYBROWN, "W"),
+	CABLE(Color.TURQUOISE, "C"),
+	FRAME(Color.DARKCYAN, "F");
+	
+	@Setter
+	private Color color;
+	@Setter
+	private String tag;
+}

--- a/src/main/java/com/hikari/hellofx/entity/Recipe.java
+++ b/src/main/java/com/hikari/hellofx/entity/Recipe.java
@@ -1,0 +1,23 @@
+package com.hikari.hellofx.entity;
+
+import java.util.Set;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public class Recipe {
+	private Set<Items> ingredients = null;
+	private Items result;
+	
+	public Recipe(Items result_) {
+		result = result_;
+	}
+	
+	public boolean test(Set<Items> items) {
+		return items.equals(ingredients);
+	}
+	
+	public Items produce() {
+		return result;
+	}
+}

--- a/src/main/java/com/hikari/hellofx/entity/Recipe.java
+++ b/src/main/java/com/hikari/hellofx/entity/Recipe.java
@@ -9,8 +9,8 @@ public class Recipe {
 	private Set<Item> ingredients = null;
 	private Item result;
 	
-	public Recipe(Item result_) {
-		result = result_;
+	public Recipe(Item result) {
+		this.result = result;
 	}
 	
 	public boolean test(Set<Item> items) {

--- a/src/main/java/com/hikari/hellofx/entity/Recipe.java
+++ b/src/main/java/com/hikari/hellofx/entity/Recipe.java
@@ -6,18 +6,18 @@ import lombok.AllArgsConstructor;
 
 @AllArgsConstructor
 public class Recipe {
-	private Set<Items> ingredients = null;
-	private Items result;
+	private Set<Item> ingredients = null;
+	private Item result;
 	
-	public Recipe(Items result_) {
+	public Recipe(Item result_) {
 		result = result_;
 	}
 	
-	public boolean test(Set<Items> items) {
+	public boolean test(Set<Item> items) {
 		return items.equals(ingredients);
 	}
 	
-	public Items produce() {
+	public Item produce() {
 		return result;
 	}
 }

--- a/src/main/java/com/hikari/hellofx/entity/RecipeManager.java
+++ b/src/main/java/com/hikari/hellofx/entity/RecipeManager.java
@@ -16,16 +16,16 @@ public class RecipeManager {
 		recipes.put(
 				EntityClassPack.MINER.getModel(), 
 				Arrays.asList(
-						new Recipe(Items.IRON),
-						new Recipe(Items.COPPER)
+						new Recipe(Item.IRON),
+						new Recipe(Item.COPPER)
 						));
 		recipes.put(
 				EntityClassPack.CONSTRUCTOR.getModel(), 
 				Arrays.asList(
-						new Recipe(Set.of(Items.IRON), Items.IRON_PLATE),
-						new Recipe(Set.of(Items.IRON), Items.IRON_ROD),
-						new Recipe(Set.of(Items.IRON_ROD), Items.SCREW),
-						new Recipe(Set.of(Items.COPPER), Items.WIRE)	
+						new Recipe(Set.of(Item.IRON), Item.IRON_PLATE),
+						new Recipe(Set.of(Item.IRON), Item.IRON_ROD),
+						new Recipe(Set.of(Item.IRON_ROD), Item.SCREW),
+						new Recipe(Set.of(Item.COPPER), Item.WIRE)	
 						));
 	}
 	public static RecipeManager instance() {
@@ -38,7 +38,7 @@ public class RecipeManager {
 		return recipes.get(producer);
 	}
 	
-	public List<Items> getAllPossibleProducables(Class<? extends IProducer> producer){
+	public List<Item> getAllPossibleProducables(Class<? extends IProducer> producer){
 		return getRecipeList(producer).stream().map(Recipe::produce).collect(Collectors.toList());
 	}
 }

--- a/src/main/java/com/hikari/hellofx/entity/RecipeManager.java
+++ b/src/main/java/com/hikari/hellofx/entity/RecipeManager.java
@@ -17,7 +17,8 @@ public class RecipeManager {
 				EntityClassPack.MINER.getModel(), 
 				Arrays.asList(
 						new Recipe(Item.IRON),
-						new Recipe(Item.COPPER)
+						new Recipe(Item.COPPER),
+						new Recipe(Item.POLYMER)
 						));
 		recipes.put(
 				EntityClassPack.CONSTRUCTOR.getModel(), 
@@ -26,6 +27,12 @@ public class RecipeManager {
 						new Recipe(Set.of(Item.IRON), Item.IRON_ROD),
 						new Recipe(Set.of(Item.IRON_ROD), Item.SCREW),
 						new Recipe(Set.of(Item.COPPER), Item.WIRE)	
+						));
+		recipes.put(EntityClassPack.ASSEMBLER.getModel(),
+				Arrays.asList(
+						new Recipe(Set.of(Item.IRON_ROD, Item.POLYMER), Item.SCREW),
+						new Recipe(Set.of(Item.WIRE, Item.POLYMER), Item.CABLE),
+						new Recipe(Set.of(Item.SCREW, Item.IRON_PLATE), Item.FRAME)
 						));
 	}
 	public static RecipeManager instance() {

--- a/src/main/java/com/hikari/hellofx/entity/RecipeManager.java
+++ b/src/main/java/com/hikari/hellofx/entity/RecipeManager.java
@@ -1,0 +1,39 @@
+package com.hikari.hellofx.entity;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Set;
+
+import com.hikari.hellofx.base.BaseModel;
+import com.hikari.hellofx.game.classpack.EntityClassPack;
+
+public class RecipeManager {
+	private HashMap<Class<? extends BaseModel>, List<Recipe>> recipes = new HashMap<>();
+	private static RecipeManager instance = null;
+	private RecipeManager() {
+		recipes.put(
+				EntityClassPack.MINER.getModel(), 
+				Arrays.asList(
+						new Recipe(Items.IRON),
+						new Recipe(Items.COPPER)
+						));
+		recipes.put(
+				EntityClassPack.CONSTRUCTOR.getModel(), 
+				Arrays.asList(
+						new Recipe(Set.of(Items.IRON), Items.IRON_PLATE),
+						new Recipe(Set.of(Items.IRON), Items.IRON_ROD),
+						new Recipe(Set.of(Items.IRON_ROD), Items.SCREW),
+						new Recipe(Set.of(Items.COPPER), Items.WIRE)	
+						));
+	}
+	public static RecipeManager instance() {
+		if(instance == null) {
+			instance = new RecipeManager();
+		}
+		return instance;
+	}
+	public List<Recipe> getRecipeList(Class<? extends IConnectable> producer) {
+		return null;
+	}
+}

--- a/src/main/java/com/hikari/hellofx/entity/RecipeManager.java
+++ b/src/main/java/com/hikari/hellofx/entity/RecipeManager.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import com.hikari.hellofx.base.BaseModel;
 import com.hikari.hellofx.game.classpack.EntityClassPack;
@@ -33,7 +34,11 @@ public class RecipeManager {
 		}
 		return instance;
 	}
-	public List<Recipe> getRecipeList(Class<? extends IConnectable> producer) {
-		return null;
+	public List<Recipe> getRecipeList(Class<? extends IProducer> producer) {
+		return recipes.get(producer);
+	}
+	
+	public List<Items> getAllPossibleProducables(Class<? extends IProducer> producer){
+		return getRecipeList(producer).stream().map(Recipe::produce).collect(Collectors.toList());
 	}
 }

--- a/src/main/java/com/hikari/hellofx/entity/RecipeManager.java
+++ b/src/main/java/com/hikari/hellofx/entity/RecipeManager.java
@@ -7,7 +7,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.hikari.hellofx.base.BaseModel;
-import com.hikari.hellofx.game.classpack.EntityClassPack;
+import com.hikari.hellofx.game.control.EntityClassPack;
 
 public class RecipeManager {
 	private HashMap<Class<? extends BaseModel>, List<Recipe>> recipes = new HashMap<>();

--- a/src/main/java/com/hikari/hellofx/entity/model/AssemblerModel.java
+++ b/src/main/java/com/hikari/hellofx/entity/model/AssemblerModel.java
@@ -2,6 +2,10 @@ package com.hikari.hellofx.entity.model;
 
 import java.util.List;
 
+import com.hikari.hellofx.entity.model.basic.BasicProducerModel;
+import com.hikari.hellofx.entity.model.cpoint.ConnectionInPoint;
+import com.hikari.hellofx.entity.model.cpoint.ConnectionOutPoint;
+
 import lombok.Getter;
 
 public class AssemblerModel extends BasicProducerModel {

--- a/src/main/java/com/hikari/hellofx/entity/model/AssemblerModel.java
+++ b/src/main/java/com/hikari/hellofx/entity/model/AssemblerModel.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 import lombok.Getter;
 
-public class AssemblerModel extends BasicEntityModel {
+public class AssemblerModel extends BasicProducerModel {
 	@Getter
 	private final ConnectionInPoint inLeft = new ConnectionInPoint(this, -0.5, 0.3);
 	@Getter

--- a/src/main/java/com/hikari/hellofx/entity/model/BasicEntityModel.java
+++ b/src/main/java/com/hikari/hellofx/entity/model/BasicEntityModel.java
@@ -2,35 +2,20 @@ package com.hikari.hellofx.entity.model;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 
 import com.hikari.hellofx.base.BaseModel;
 import com.hikari.hellofx.base.BaseService;
 import com.hikari.hellofx.entity.IConnectable;
 import com.hikari.hellofx.entity.IPowerConnectable;
-import com.hikari.hellofx.entity.IProducer;
 import com.hikari.hellofx.entity.IServiceNotifier;
-import com.hikari.hellofx.entity.Items;
-import com.hikari.hellofx.entity.Recipe;
-import com.hikari.hellofx.entity.RecipeManager;
 
-import lombok.Getter;
-
-public abstract class BasicEntityModel extends BaseModel implements IConnectable, IPowerConnectable, IServiceNotifier, IProducer{
+public abstract class BasicEntityModel extends BaseModel implements IConnectable, IPowerConnectable, IServiceNotifier {
 	private Object payload = null;
 	private boolean isTurnedOn = false;
 	private BaseService basicService = null;
-	@Getter
-	private Recipe currentRecipe;
 	private ConnectableState state = ConnectableState.NO_POINTS;
 	
-	@Override
-	public void setCurrentRecipe(Items item) throws NoSuchElementException{
-		List<Recipe> list =  RecipeManager.instance().getRecipeList(this.getClass());
-		currentRecipe = list.stream().filter(r -> r.produce() == item).findFirst().orElseThrow();
-	}
-
 	@Override
 	public void turnOff() {
 		isTurnedOn = false;

--- a/src/main/java/com/hikari/hellofx/entity/model/BasicEntityModel.java
+++ b/src/main/java/com/hikari/hellofx/entity/model/BasicEntityModel.java
@@ -18,7 +18,7 @@ public abstract class BasicEntityModel extends BaseModel implements IConnectable
 	private boolean isTurnedOn = false;
 	private BaseService basicService = null;
 	private ConnectableState state = ConnectableState.NO_POINTS;
-	
+
 	@Override
 	public void turnOff() {
 		isTurnedOn = false;
@@ -52,7 +52,7 @@ public abstract class BasicEntityModel extends BaseModel implements IConnectable
 		this.state = state;
 		notifySubs();
 	}
-	
+
 	@Override
 	public synchronized Integer getFillCount() {
 		return payload == null ? 0 : 1;
@@ -60,8 +60,8 @@ public abstract class BasicEntityModel extends BaseModel implements IConnectable
 
 	@SafeVarargs
 	protected final <T extends ConnectionPoint> List<T> packPoints(T... args) {
-		return Arrays.asList(args).stream().filter(w -> (w.isFree()))
-				.collect(Collectors.toUnmodifiableList());
+		// ConnectionPoint::isFree logic was delegated to filterFreePoints
+		return Arrays.asList(args).stream().collect(Collectors.toUnmodifiableList());
 	}
 
 	@Override
@@ -73,5 +73,11 @@ public abstract class BasicEntityModel extends BaseModel implements IConnectable
 	public void disconnectService() {
 		basicService = null;
 	}
-	
+
+	public List<ConnectionPoint> filterFreePoints(Class<? extends ConnectionPoint> point) {
+		List<? extends ConnectionPoint> list = 
+				(point.equals(ConnectionInPoint.class) ? getInPoints() : getOutPoints());
+		return list.stream().filter(ConnectionPoint::isFree).collect(Collectors.toUnmodifiableList());
+	}
+
 }

--- a/src/main/java/com/hikari/hellofx/entity/model/BasicEntityModel.java
+++ b/src/main/java/com/hikari/hellofx/entity/model/BasicEntityModel.java
@@ -54,10 +54,6 @@ public abstract class BasicEntityModel extends BaseModel implements IConnectable
 		return isTurnedOn;
 	}
 
-	public void despawn() {
-		// TODO
-	}
-
 	@Override
 	public ConnectableState getConnectableState() {
 		return state;

--- a/src/main/java/com/hikari/hellofx/entity/model/BasicEntityModel.java
+++ b/src/main/java/com/hikari/hellofx/entity/model/BasicEntityModel.java
@@ -10,7 +10,10 @@ import com.hikari.hellofx.entity.IConnectable;
 import com.hikari.hellofx.entity.IPowerConnectable;
 import com.hikari.hellofx.entity.IServiceNotifier;
 
+import lombok.Setter;
+
 public abstract class BasicEntityModel extends BaseModel implements IConnectable, IPowerConnectable, IServiceNotifier {
+	@Setter
 	private Object payload = null;
 	private boolean isTurnedOn = false;
 	private BaseService basicService = null;
@@ -45,13 +48,9 @@ public abstract class BasicEntityModel extends BaseModel implements IConnectable
 	}
 
 	@Override
-	public void setConnectableState(ConnectableState state_) {
-		state = state_;
+	public void setConnectableState(ConnectableState state) {
+		this.state = state;
 		notifySubs();
-	}
-	
-	public synchronized void setPayload(Object o) {
-		payload = o; 
 	}
 	
 	@Override

--- a/src/main/java/com/hikari/hellofx/entity/model/BasicEntityModel.java
+++ b/src/main/java/com/hikari/hellofx/entity/model/BasicEntityModel.java
@@ -2,19 +2,34 @@ package com.hikari.hellofx.entity.model;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 
 import com.hikari.hellofx.base.BaseModel;
 import com.hikari.hellofx.base.BaseService;
 import com.hikari.hellofx.entity.IConnectable;
 import com.hikari.hellofx.entity.IPowerConnectable;
-import com.hikari.hellofx.entity.IServiceable;
+import com.hikari.hellofx.entity.IProducer;
+import com.hikari.hellofx.entity.IServiceNotifier;
+import com.hikari.hellofx.entity.Items;
+import com.hikari.hellofx.entity.Recipe;
+import com.hikari.hellofx.entity.RecipeManager;
 
-public abstract class BasicEntityModel extends BaseModel implements IConnectable, IPowerConnectable, IServiceable{
+import lombok.Getter;
+
+public abstract class BasicEntityModel extends BaseModel implements IConnectable, IPowerConnectable, IServiceNotifier, IProducer{
 	private Object payload = null;
 	private boolean isTurnedOn = false;
 	private BaseService basicService = null;
+	@Getter
+	private Recipe currentRecipe;
 	private ConnectableState state = ConnectableState.NO_POINTS;
+	
+	@Override
+	public void setCurrentRecipe(Items item) throws NoSuchElementException{
+		List<Recipe> list =  RecipeManager.instance().getRecipeList(this.getClass());
+		currentRecipe = list.stream().filter(r -> r.produce() == item).findFirst().orElseThrow();
+	}
 
 	@Override
 	public void turnOff() {
@@ -69,11 +84,14 @@ public abstract class BasicEntityModel extends BaseModel implements IConnectable
 				.collect(Collectors.toUnmodifiableList());
 	}
 
+	@Override
 	public void connectService(BaseService service) {
 		basicService = service;
 	}
 
+	@Override
 	public void disconnectService() {
 		basicService = null;
 	}
+	
 }

--- a/src/main/java/com/hikari/hellofx/entity/model/BasicProducerModel.java
+++ b/src/main/java/com/hikari/hellofx/entity/model/BasicProducerModel.java
@@ -4,19 +4,24 @@ import java.util.List;
 import java.util.NoSuchElementException;
 
 import com.hikari.hellofx.entity.IProducer;
-import com.hikari.hellofx.entity.Items;
+import com.hikari.hellofx.entity.Item;
 import com.hikari.hellofx.entity.Recipe;
 import com.hikari.hellofx.entity.RecipeManager;
 
 import lombok.Getter;
+import lombok.extern.log4j.Log4j2;
 
+@Log4j2
 public abstract class BasicProducerModel extends BasicEntityModel implements IProducer{
 	@Getter
 	private Recipe currentRecipe;
 	
+	//TODO override turnOn for getting first recipe
+	
 	@Override
-	public void setCurrentRecipe(Items item) throws NoSuchElementException{
+	public void setCurrentRecipe(Item item) throws NoSuchElementException{
 		List<Recipe> list =  RecipeManager.instance().getRecipeList(this.getClass());
 		currentRecipe = list.stream().filter(r -> r.produce() == item).findFirst().orElseThrow();
+		log.info(currentRecipe.produce().toString());
 	}
 }

--- a/src/main/java/com/hikari/hellofx/entity/model/BasicProducerModel.java
+++ b/src/main/java/com/hikari/hellofx/entity/model/BasicProducerModel.java
@@ -1,0 +1,22 @@
+package com.hikari.hellofx.entity.model;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import com.hikari.hellofx.entity.IProducer;
+import com.hikari.hellofx.entity.Items;
+import com.hikari.hellofx.entity.Recipe;
+import com.hikari.hellofx.entity.RecipeManager;
+
+import lombok.Getter;
+
+public abstract class BasicProducerModel extends BasicEntityModel implements IProducer{
+	@Getter
+	private Recipe currentRecipe;
+	
+	@Override
+	public void setCurrentRecipe(Items item) throws NoSuchElementException{
+		List<Recipe> list =  RecipeManager.instance().getRecipeList(this.getClass());
+		currentRecipe = list.stream().filter(r -> r.produce() == item).findFirst().orElseThrow();
+	}
+}

--- a/src/main/java/com/hikari/hellofx/entity/model/ConnectionInPoint.java
+++ b/src/main/java/com/hikari/hellofx/entity/model/ConnectionInPoint.java
@@ -1,9 +1,9 @@
 package com.hikari.hellofx.entity.model;
 
-import com.hikari.hellofx.entity.IServiceable;
+import com.hikari.hellofx.entity.IServiceNotifier;
 
 public class ConnectionInPoint extends ConnectionPoint{
-	public ConnectionInPoint(IServiceable entity, Double offsetX, Double offsetY) {
+	public ConnectionInPoint(IServiceNotifier entity, Double offsetX, Double offsetY) {
 		super(entity, offsetX, offsetY);
 	}
 }

--- a/src/main/java/com/hikari/hellofx/entity/model/ConnectionOutPoint.java
+++ b/src/main/java/com/hikari/hellofx/entity/model/ConnectionOutPoint.java
@@ -1,9 +1,9 @@
 package com.hikari.hellofx.entity.model;
 
-import com.hikari.hellofx.entity.IServiceable;
+import com.hikari.hellofx.entity.IServiceNotifier;
 
 public class ConnectionOutPoint extends ConnectionPoint{
-	public ConnectionOutPoint(IServiceable entity, Double offsetX, Double offsetY) {
+	public ConnectionOutPoint(IServiceNotifier entity, Double offsetX, Double offsetY) {
 		super(entity, offsetX, offsetY);
 	}
 }

--- a/src/main/java/com/hikari/hellofx/entity/model/ConnectionPoint.java
+++ b/src/main/java/com/hikari/hellofx/entity/model/ConnectionPoint.java
@@ -4,7 +4,7 @@ import java.util.concurrent.Semaphore;
 
 import com.hikari.hellofx.base.BaseModel;
 import com.hikari.hellofx.entity.IConnection;
-import com.hikari.hellofx.entity.IServiceable;
+import com.hikari.hellofx.entity.IServiceNotifier;
 
 import lombok.Getter;
 import lombok.extern.log4j.Log4j2;
@@ -23,14 +23,14 @@ public class ConnectionPoint extends BaseModel {
 	@Getter
 	private double lastViewY; //
 	protected IConnection connection = null;
-	private final IServiceable parentEntity;
+	private final IServiceNotifier parentEntity;
 
 	private static final int INTHREADSCOUNT = 1;
 	private final Semaphore isEmpty = new Semaphore(INTHREADSCOUNT);
 	private final Semaphore isFull = new Semaphore(0);
 	private Object heldObject = null;
 
-	public ConnectionPoint(IServiceable entity, Double offsetX_, Double offsetY_) {
+	public ConnectionPoint(IServiceNotifier entity, Double offsetX_, Double offsetY_) {
 		parentEntity = entity;
 		offsetX = offsetX_;
 		offsetY = offsetY_;
@@ -112,7 +112,7 @@ public class ConnectionPoint extends BaseModel {
 	}
 	
 	//this two for preventing self-connecting with spawner
-	IServiceable getParentEntity() {
+	IServiceNotifier getParentEntity() {
 		return parentEntity;
 	}
 	

--- a/src/main/java/com/hikari/hellofx/entity/model/ConnectionPoint.java
+++ b/src/main/java/com/hikari/hellofx/entity/model/ConnectionPoint.java
@@ -20,7 +20,7 @@ public class ConnectionPoint extends BaseModel {
 	@Getter
 	private final Double offsetY;
 	@Getter
-	private double lastViewX; // TODO may be mvc leak??
+	private double lastViewX;
 	@Getter
 	private double lastViewY; 
 	@Getter
@@ -58,12 +58,12 @@ public class ConnectionPoint extends BaseModel {
 		connection = null;
 	}
 
-	public void setLastViewX(Double lastViewX_) {
-		lastViewX = lastViewX_;
+	public void setLastViewX(Double lastViewX) {
+		this.lastViewX = lastViewX;
 	}
 
-	public void setLastViewY(Double lastViewY_) {
-		lastViewY = lastViewY_;
+	public void setLastViewY(Double lastViewY) {
+		this.lastViewY = lastViewY;
 	}
 
 	public Item get() throws InterruptedException {

--- a/src/main/java/com/hikari/hellofx/entity/model/ConnectionPoint.java
+++ b/src/main/java/com/hikari/hellofx/entity/model/ConnectionPoint.java
@@ -5,6 +5,7 @@ import java.util.concurrent.Semaphore;
 import com.hikari.hellofx.base.BaseModel;
 import com.hikari.hellofx.entity.IConnection;
 import com.hikari.hellofx.entity.IServiceNotifier;
+import com.hikari.hellofx.entity.Item;
 
 import lombok.Getter;
 import lombok.extern.log4j.Log4j2;
@@ -28,7 +29,7 @@ public class ConnectionPoint extends BaseModel {
 	private static final int INTHREADSCOUNT = 1;
 	private final Semaphore isEmpty = new Semaphore(INTHREADSCOUNT);
 	private final Semaphore isFull = new Semaphore(0);
-	private Object heldObject = null;
+	private Item heldObject = null;
 
 	public ConnectionPoint(IServiceNotifier entity, Double offsetX_, Double offsetY_) {
 		parentEntity = entity;
@@ -65,7 +66,7 @@ public class ConnectionPoint extends BaseModel {
 		lastViewY = lastViewY_;
 	}
 
-	public Object get() throws InterruptedException {
+	public Item get() throws InterruptedException {
 		// TODO add checking for exact connected connection/connectable?
 		isFull.acquire();
 		log.debug(" giving " + heldObject.toString());
@@ -76,7 +77,7 @@ public class ConnectionPoint extends BaseModel {
 		return res;
 	}
 
-	public void put(Object o) throws InterruptedException {
+	public void put(Item o) throws InterruptedException {
 		isEmpty.acquire();
 		heldObject = o;
 		log.debug(" taking " + heldObject.toString());
@@ -84,7 +85,7 @@ public class ConnectionPoint extends BaseModel {
 		notifyParentService();
 	}
 
-	public boolean offer(Object o) {
+	public boolean offer(Item o) {
 		if (!isEmpty.tryAcquire()) {
 			log.debug(" -offered ");
 			return false;
@@ -97,7 +98,7 @@ public class ConnectionPoint extends BaseModel {
 		}
 	}
 
-	public Object poll() {
+	public Item poll() {
 		if (!isFull.tryAcquire()) {
 			log.debug(" -polled ");
 			return null;
@@ -117,6 +118,6 @@ public class ConnectionPoint extends BaseModel {
 	}
 	
 	public boolean parentEquals(ConnectionPoint other) {
-		return parentEntity.equals(other);
+		return parentEntity.equals(other.getParentEntity());
 	}
 }

--- a/src/main/java/com/hikari/hellofx/entity/model/ConnectionPoint.java
+++ b/src/main/java/com/hikari/hellofx/entity/model/ConnectionPoint.java
@@ -22,7 +22,8 @@ public class ConnectionPoint extends BaseModel {
 	@Getter
 	private double lastViewX; // TODO may be mvc leak??
 	@Getter
-	private double lastViewY; //
+	private double lastViewY; 
+	@Getter
 	protected IConnection connection = null;
 	private final IServiceNotifier parentEntity;
 
@@ -54,7 +55,6 @@ public class ConnectionPoint extends BaseModel {
 	}
 
 	public void disconnect() {
-		// connection.disconnect()?
 		connection = null;
 	}
 

--- a/src/main/java/com/hikari/hellofx/entity/model/ConnectionPoint.java
+++ b/src/main/java/com/hikari/hellofx/entity/model/ConnectionPoint.java
@@ -117,6 +117,6 @@ public class ConnectionPoint extends BaseModel {
 	}
 	
 	public boolean parentEquals(ConnectionPoint other) {
-		return parentEntity.equals(parentEntity);
+		return parentEntity.equals(other);
 	}
 }

--- a/src/main/java/com/hikari/hellofx/entity/model/ConstructorModel.java
+++ b/src/main/java/com/hikari/hellofx/entity/model/ConstructorModel.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 import lombok.Getter;
 
-public class ConstructorModel extends BasicEntityModel {
+public class ConstructorModel extends BasicProducerModel {
 	@Getter
 	private final ConnectionInPoint in = new ConnectionInPoint(this, -0.5, 0.0);
 	@Getter

--- a/src/main/java/com/hikari/hellofx/entity/model/ConstructorModel.java
+++ b/src/main/java/com/hikari/hellofx/entity/model/ConstructorModel.java
@@ -2,6 +2,10 @@ package com.hikari.hellofx.entity.model;
 
 import java.util.List;
 
+import com.hikari.hellofx.entity.model.basic.BasicProducerModel;
+import com.hikari.hellofx.entity.model.cpoint.ConnectionInPoint;
+import com.hikari.hellofx.entity.model.cpoint.ConnectionOutPoint;
+
 import lombok.Getter;
 
 public class ConstructorModel extends BasicProducerModel {

--- a/src/main/java/com/hikari/hellofx/entity/model/EntityShadow.java
+++ b/src/main/java/com/hikari/hellofx/entity/model/EntityShadow.java
@@ -9,9 +9,9 @@ public class EntityShadow extends BaseModel {
 	private double x = 0.0;
 	private double y = 0.0;
 
-	public void move(double x_, double y_) {
-		x = x_;
-		y = y_;
+	public void move(double x, double y) {
+		this.x = x;
+		this.y = y;
 		notifySubs();
 	}
 }

--- a/src/main/java/com/hikari/hellofx/entity/model/MergerModel.java
+++ b/src/main/java/com/hikari/hellofx/entity/model/MergerModel.java
@@ -43,11 +43,6 @@ public class MergerModel extends BasicEntityModel {
 		turnOn();
 	}
 
-	public int amountOfConnectedPoints() {
-		return ins.stream().map(o -> (o.isFree() ? 0 : 1)).reduce(0, (a, b) -> a + b);
-
-	}
-
 	@Override
 	public synchronized Integer getFillCount() {
 		// nothing stays inside

--- a/src/main/java/com/hikari/hellofx/entity/model/MergerModel.java
+++ b/src/main/java/com/hikari/hellofx/entity/model/MergerModel.java
@@ -1,0 +1,54 @@
+package com.hikari.hellofx.entity.model;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.hikari.hellofx.base.BaseService;
+
+import lombok.Getter;
+
+public class MergerModel extends BasicEntityModel {
+	@Getter
+	private final ConnectionOutPoint out = new ConnectionOutPoint(this, 0.5, 0.0);
+	private final ConnectionInPoint inFirst;
+	private final ConnectionInPoint inSecond;
+	private final ConnectionInPoint inThird;
+	@Getter
+	private final List<ConnectionInPoint> ins;
+
+	public MergerModel() {
+		inFirst = new ConnectionInPoint(this, 0.0, 0.5);
+		inSecond = new ConnectionInPoint(this, -0.5, 0.0);
+		inThird = new ConnectionInPoint(this, 0.0, -0.5);
+		ins = Stream.of(inFirst, inSecond, inThird).collect(Collectors.toList());
+	}
+
+	@Override
+	public List<ConnectionInPoint> getInPoints() {
+		return packPoints(inFirst, inSecond, inThird);
+	}
+
+	@Override
+	public List<ConnectionOutPoint> getOutPoints() {
+		return packPoints(out);
+	}
+	
+	@Override
+	public void connectService(BaseService service) {
+		super.connectService(service);
+		turnOn();
+	}
+
+	public int amountOfConnectedPoints() {
+		return ins.stream().map((o) -> (o.isFree() ? 0 : 1)).reduce(0, (a, b) -> a + b);
+
+	}
+
+	@Override
+	public synchronized Integer getFillCount() {
+		// nothing stays inside
+		return 0;
+	}
+
+}

--- a/src/main/java/com/hikari/hellofx/entity/model/MergerModel.java
+++ b/src/main/java/com/hikari/hellofx/entity/model/MergerModel.java
@@ -5,6 +5,9 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.hikari.hellofx.base.BaseService;
+import com.hikari.hellofx.entity.model.basic.BasicEntityModel;
+import com.hikari.hellofx.entity.model.cpoint.ConnectionInPoint;
+import com.hikari.hellofx.entity.model.cpoint.ConnectionOutPoint;
 
 import lombok.Getter;
 
@@ -41,7 +44,7 @@ public class MergerModel extends BasicEntityModel {
 	}
 
 	public int amountOfConnectedPoints() {
-		return ins.stream().map((o) -> (o.isFree() ? 0 : 1)).reduce(0, (a, b) -> a + b);
+		return ins.stream().map(o -> (o.isFree() ? 0 : 1)).reduce(0, (a, b) -> a + b);
 
 	}
 

--- a/src/main/java/com/hikari/hellofx/entity/model/MinerModel.java
+++ b/src/main/java/com/hikari/hellofx/entity/model/MinerModel.java
@@ -3,6 +3,10 @@ package com.hikari.hellofx.entity.model;
 import java.util.Collections;
 import java.util.List;
 
+import com.hikari.hellofx.entity.model.basic.BasicProducerModel;
+import com.hikari.hellofx.entity.model.cpoint.ConnectionInPoint;
+import com.hikari.hellofx.entity.model.cpoint.ConnectionOutPoint;
+
 import lombok.Getter;
 
 public class MinerModel extends BasicProducerModel{

--- a/src/main/java/com/hikari/hellofx/entity/model/MinerModel.java
+++ b/src/main/java/com/hikari/hellofx/entity/model/MinerModel.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 import lombok.Getter;
 
-public class MinerModel extends BasicEntityModel{
+public class MinerModel extends BasicProducerModel{
 	@Getter
 	private final ConnectionOutPoint out = new ConnectionOutPoint(this, 0.5, 0.0);
 	

--- a/src/main/java/com/hikari/hellofx/entity/model/SplitterModel.java
+++ b/src/main/java/com/hikari/hellofx/entity/model/SplitterModel.java
@@ -43,11 +43,6 @@ public class SplitterModel extends BasicEntityModel {
 		turnOn();
 	}
 
-	public int amountOfConnectedPoints() {
-		return outs.stream().map(o -> (o.isFree() ? 0 : 1)).reduce(0, (a, b) -> a + b);
-
-	}
-
 	@Override
 	public synchronized Integer getFillCount() {
 		// nothing stays inside

--- a/src/main/java/com/hikari/hellofx/entity/model/SplitterModel.java
+++ b/src/main/java/com/hikari/hellofx/entity/model/SplitterModel.java
@@ -5,6 +5,9 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.hikari.hellofx.base.BaseService;
+import com.hikari.hellofx.entity.model.basic.BasicEntityModel;
+import com.hikari.hellofx.entity.model.cpoint.ConnectionInPoint;
+import com.hikari.hellofx.entity.model.cpoint.ConnectionOutPoint;
 
 import lombok.Getter;
 

--- a/src/main/java/com/hikari/hellofx/entity/model/SplitterModel.java
+++ b/src/main/java/com/hikari/hellofx/entity/model/SplitterModel.java
@@ -44,7 +44,7 @@ public class SplitterModel extends BasicEntityModel {
 	}
 
 	public int amountOfConnectedPoints() {
-		return outs.stream().map((o) -> (o.isFree() ? 0 : 1)).reduce(0, (a, b) -> a + b);
+		return outs.stream().map(o -> (o.isFree() ? 0 : 1)).reduce(0, (a, b) -> a + b);
 
 	}
 

--- a/src/main/java/com/hikari/hellofx/entity/model/StorageModel.java
+++ b/src/main/java/com/hikari/hellofx/entity/model/StorageModel.java
@@ -1,23 +1,28 @@
 package com.hikari.hellofx.entity.model;
 
-import java.util.ArrayDeque;
 import java.util.List;
+import java.util.Map;
 
+import com.hikari.hellofx.entity.Item;
 import com.hikari.hellofx.entity.model.basic.BasicEntityModel;
 import com.hikari.hellofx.entity.model.cpoint.ConnectionInPoint;
 import com.hikari.hellofx.entity.model.cpoint.ConnectionOutPoint;
 
 import lombok.Getter;
+import lombok.extern.log4j.Log4j2;
 
 import java.util.Collections;
+import java.util.HashMap;
 
-public class StorageModel extends BasicEntityModel{
-	private static final int STORAGE_SIZE = 100;
+@Log4j2
+public class StorageModel extends BasicEntityModel {
 	@Getter
-	private final ArrayDeque<Object> storage = new ArrayDeque<>(STORAGE_SIZE);
+	private final Map<String, Integer> storage = new HashMap<>();
 	@Getter
 	private final ConnectionInPoint in = new ConnectionInPoint(this, -0.5, 0.0);
-	
+	@Getter
+	private Integer storageSize = 0;
+
 	@Override
 	public List<ConnectionInPoint> getInPoints() {
 		return packPoints(in);
@@ -30,6 +35,12 @@ public class StorageModel extends BasicEntityModel{
 
 	@Override
 	public synchronized Integer getFillCount() {
-		return storage.size();
+		return storageSize;
+	}
+
+	public void addItem(Item o) {
+		storage.merge(o.toString(), 1, ((a,b) -> a + b));
+		storageSize++;
+		log.info(storage);
 	}
 }

--- a/src/main/java/com/hikari/hellofx/entity/model/StorageModel.java
+++ b/src/main/java/com/hikari/hellofx/entity/model/StorageModel.java
@@ -14,7 +14,7 @@ import java.util.Collections;
 public class StorageModel extends BasicEntityModel{
 	private static final int STORAGE_SIZE = 100;
 	@Getter
-	private final ArrayDeque<Object> storage = new ArrayDeque<Object>(STORAGE_SIZE);
+	private final ArrayDeque<Object> storage = new ArrayDeque<>(STORAGE_SIZE);
 	@Getter
 	private final ConnectionInPoint in = new ConnectionInPoint(this, -0.5, 0.0);
 	
@@ -29,7 +29,7 @@ public class StorageModel extends BasicEntityModel{
 	}
 
 	@Override
-	public Integer getFillCount() {
+	public synchronized Integer getFillCount() {
 		return storage.size();
 	}
 }

--- a/src/main/java/com/hikari/hellofx/entity/model/StorageModel.java
+++ b/src/main/java/com/hikari/hellofx/entity/model/StorageModel.java
@@ -3,6 +3,10 @@ package com.hikari.hellofx.entity.model;
 import java.util.ArrayDeque;
 import java.util.List;
 
+import com.hikari.hellofx.entity.model.basic.BasicEntityModel;
+import com.hikari.hellofx.entity.model.cpoint.ConnectionInPoint;
+import com.hikari.hellofx.entity.model.cpoint.ConnectionOutPoint;
+
 import lombok.Getter;
 
 import java.util.Collections;

--- a/src/main/java/com/hikari/hellofx/entity/model/StorageModel.java
+++ b/src/main/java/com/hikari/hellofx/entity/model/StorageModel.java
@@ -9,12 +9,10 @@ import com.hikari.hellofx.entity.model.cpoint.ConnectionInPoint;
 import com.hikari.hellofx.entity.model.cpoint.ConnectionOutPoint;
 
 import lombok.Getter;
-import lombok.extern.log4j.Log4j2;
 
 import java.util.Collections;
 import java.util.HashMap;
 
-@Log4j2
 public class StorageModel extends BasicEntityModel {
 	@Getter
 	private final Map<String, Integer> storage = new HashMap<>();
@@ -41,6 +39,5 @@ public class StorageModel extends BasicEntityModel {
 	public void addItem(Item o) {
 		storage.merge(o.toString(), 1, ((a,b) -> a + b));
 		storageSize++;
-		log.info(storage);
 	}
 }

--- a/src/main/java/com/hikari/hellofx/entity/model/basic/BasicConnectionModel.java
+++ b/src/main/java/com/hikari/hellofx/entity/model/basic/BasicConnectionModel.java
@@ -1,0 +1,35 @@
+package com.hikari.hellofx.entity.model.basic;
+
+import com.hikari.hellofx.base.BaseModel;
+import com.hikari.hellofx.entity.IConnection;
+import com.hikari.hellofx.entity.ISuspendable;
+
+public abstract class BasicConnectionModel extends BaseModel implements IConnection, ISuspendable{
+	private boolean isDetached = false;
+	
+	@Override
+	public void turnOff() {
+		//always on
+	}
+
+	@Override
+	public void turnOn() {
+		//always on
+	}
+
+	@Override
+	public boolean isOn() {
+		return true;
+	}
+	
+	@Override
+	public void markDetached() {
+		isDetached = true;
+	}
+
+	@Override
+	public boolean isDetached() {
+		return isDetached;
+	}
+
+}

--- a/src/main/java/com/hikari/hellofx/entity/model/basic/BasicConnectionModel.java
+++ b/src/main/java/com/hikari/hellofx/entity/model/basic/BasicConnectionModel.java
@@ -8,17 +8,17 @@ public abstract class BasicConnectionModel extends BaseModel implements IConnect
 	private boolean isDetached = false;
 	
 	@Override
-	public void turnOff() {
+	public synchronized void turnOff() {
 		//always on
 	}
 
 	@Override
-	public void turnOn() {
+	public synchronized void turnOn() {
 		//always on
 	}
 
 	@Override
-	public boolean isOn() {
+	public synchronized boolean isOn() {
 		return true;
 	}
 	

--- a/src/main/java/com/hikari/hellofx/entity/model/basic/BasicConnectionModel.java
+++ b/src/main/java/com/hikari/hellofx/entity/model/basic/BasicConnectionModel.java
@@ -3,9 +3,14 @@ package com.hikari.hellofx.entity.model.basic;
 import com.hikari.hellofx.base.BaseModel;
 import com.hikari.hellofx.entity.IConnection;
 import com.hikari.hellofx.entity.ISuspendable;
+import com.hikari.hellofx.entity.model.cpoint.ConnectionInPoint;
+import com.hikari.hellofx.entity.model.cpoint.ConnectionOutPoint;
 
 public abstract class BasicConnectionModel extends BaseModel implements IConnection, ISuspendable{
 	private boolean isDetached = false;
+	
+	public abstract ConnectionInPoint getDst();
+	public abstract ConnectionOutPoint getSrc();
 	
 	@Override
 	public synchronized void turnOff() {

--- a/src/main/java/com/hikari/hellofx/entity/model/basic/BasicEntityModel.java
+++ b/src/main/java/com/hikari/hellofx/entity/model/basic/BasicEntityModel.java
@@ -14,7 +14,9 @@ import com.hikari.hellofx.entity.model.cpoint.ConnectionInPoint;
 import com.hikari.hellofx.entity.model.cpoint.ConnectionPoint;
 
 import lombok.Setter;
+import lombok.extern.log4j.Log4j2;
 
+@Log4j2
 public abstract class BasicEntityModel extends BaseModel implements IConnectable, IPowerConnectable, IServiceNotifier {
 	@Setter
 	private Object payload = null;
@@ -30,6 +32,8 @@ public abstract class BasicEntityModel extends BaseModel implements IConnectable
 
 	public void notifyService() {
 		synchronized (basicService.getMonitor()) {
+			log.info("notified");
+			basicService.armItemsQueued();
 			basicService.getMonitor().notifyAll();
 		}
 	}
@@ -78,8 +82,7 @@ public abstract class BasicEntityModel extends BaseModel implements IConnectable
 	}
 
 	public List<ConnectionPoint> filterFreePoints(Class<? extends ConnectionPoint> point) {
-		List<? extends ConnectionPoint> list = 
-				(point.equals(ConnectionInPoint.class) ? getInPoints() : getOutPoints());
+		List<? extends ConnectionPoint> list = (point.equals(ConnectionInPoint.class) ? getInPoints() : getOutPoints());
 		return list.stream().filter(ConnectionPoint::isFree).collect(Collectors.toUnmodifiableList());
 	}
 

--- a/src/main/java/com/hikari/hellofx/entity/model/basic/BasicEntityModel.java
+++ b/src/main/java/com/hikari/hellofx/entity/model/basic/BasicEntityModel.java
@@ -2,6 +2,7 @@ package com.hikari.hellofx.entity.model.basic;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import com.hikari.hellofx.base.BaseModel;
@@ -79,8 +80,17 @@ public abstract class BasicEntityModel extends BaseModel implements IConnectable
 	}
 
 	public List<ConnectionPoint> filterFreePoints(Class<? extends ConnectionPoint> point) {
-		List<? extends ConnectionPoint> list = (point.equals(ConnectionInPoint.class) ? getInPoints() : getOutPoints());
-		return list.stream().filter(ConnectionPoint::isFree).collect(Collectors.toUnmodifiableList());
+		return filterPoints(point, ConnectionPoint::isFree);
+	}
+
+	public List<ConnectionPoint> filterNonFreePoints(Class<? extends ConnectionPoint> point) {
+		return filterPoints(point, (p -> !p.isFree()));
+	}
+
+	public List<ConnectionPoint> filterPoints(Class<? extends ConnectionPoint> point,
+			Predicate<? super ConnectionPoint> predicate) {
+		return (point.equals(ConnectionInPoint.class) ? getInPoints() : getOutPoints()).stream().filter(predicate)
+				.collect(Collectors.toUnmodifiableList());
 	}
 
 }

--- a/src/main/java/com/hikari/hellofx/entity/model/basic/BasicEntityModel.java
+++ b/src/main/java/com/hikari/hellofx/entity/model/basic/BasicEntityModel.java
@@ -1,4 +1,4 @@
-package com.hikari.hellofx.entity.model;
+package com.hikari.hellofx.entity.model.basic;
 
 import java.util.Arrays;
 import java.util.List;
@@ -9,6 +9,9 @@ import com.hikari.hellofx.base.BaseService;
 import com.hikari.hellofx.entity.IConnectable;
 import com.hikari.hellofx.entity.IPowerConnectable;
 import com.hikari.hellofx.entity.IServiceNotifier;
+import com.hikari.hellofx.entity.model.ConnectableState;
+import com.hikari.hellofx.entity.model.cpoint.ConnectionInPoint;
+import com.hikari.hellofx.entity.model.cpoint.ConnectionPoint;
 
 import lombok.Setter;
 
@@ -26,8 +29,8 @@ public abstract class BasicEntityModel extends BaseModel implements IConnectable
 	}
 
 	public void notifyService() {
-		synchronized (basicService) {
-			basicService.notify();
+		synchronized (basicService.getMonitor()) {
+			basicService.getMonitor().notifyAll();
 		}
 	}
 

--- a/src/main/java/com/hikari/hellofx/entity/model/basic/BasicEntityModel.java
+++ b/src/main/java/com/hikari/hellofx/entity/model/basic/BasicEntityModel.java
@@ -14,9 +14,7 @@ import com.hikari.hellofx.entity.model.cpoint.ConnectionInPoint;
 import com.hikari.hellofx.entity.model.cpoint.ConnectionPoint;
 
 import lombok.Setter;
-import lombok.extern.log4j.Log4j2;
 
-@Log4j2
 public abstract class BasicEntityModel extends BaseModel implements IConnectable, IPowerConnectable, IServiceNotifier {
 	@Setter
 	private Object payload = null;
@@ -32,7 +30,6 @@ public abstract class BasicEntityModel extends BaseModel implements IConnectable
 
 	public void notifyService() {
 		synchronized (basicService.getMonitor()) {
-			log.info("notified");
 			basicService.armItemsQueued();
 			basicService.getMonitor().notifyAll();
 		}

--- a/src/main/java/com/hikari/hellofx/entity/model/basic/BasicEntityModel.java
+++ b/src/main/java/com/hikari/hellofx/entity/model/basic/BasicEntityModel.java
@@ -23,7 +23,7 @@ public abstract class BasicEntityModel extends BaseModel implements IConnectable
 	private ConnectableState state = ConnectableState.NO_POINTS;
 
 	@Override
-	public void turnOff() {
+	public synchronized void turnOff() {
 		isTurnedOn = false;
 		super.notifySubs();
 	}
@@ -35,13 +35,13 @@ public abstract class BasicEntityModel extends BaseModel implements IConnectable
 	}
 
 	@Override
-	public void turnOn() {
+	public synchronized void turnOn() {
 		isTurnedOn = true;
 		notifyService();
 		super.notifySubs();
 	}
 
-	public boolean isOn() {
+	public synchronized boolean isOn() {
 		return isTurnedOn;
 	}
 

--- a/src/main/java/com/hikari/hellofx/entity/model/basic/BasicProducerModel.java
+++ b/src/main/java/com/hikari/hellofx/entity/model/basic/BasicProducerModel.java
@@ -1,4 +1,4 @@
-package com.hikari.hellofx.entity.model;
+package com.hikari.hellofx.entity.model.basic;
 
 import java.util.List;
 import java.util.NoSuchElementException;

--- a/src/main/java/com/hikari/hellofx/entity/model/basic/BasicProducerModel.java
+++ b/src/main/java/com/hikari/hellofx/entity/model/basic/BasicProducerModel.java
@@ -14,9 +14,7 @@ import lombok.extern.log4j.Log4j2;
 @Log4j2
 public abstract class BasicProducerModel extends BasicEntityModel implements IProducer{
 	@Getter
-	private Recipe currentRecipe;
-	
-	//TODO override turnOn for getting first recipe
+	private Recipe currentRecipe = RecipeManager.instance().getRecipeList(this.getClass()).get(0);
 	
 	@Override
 	public void setCurrentRecipe(Item item) throws NoSuchElementException{

--- a/src/main/java/com/hikari/hellofx/entity/model/belt/Belt.java
+++ b/src/main/java/com/hikari/hellofx/entity/model/belt/Belt.java
@@ -22,7 +22,7 @@ public class Belt extends BaseModel implements IConnection, ISuspendable {
 	private int slotsCount;
 
 	// 0 .. slotsCount - 1
-	private List<ModelItem> items;
+	private List<ItemCarriage> items;
 	@Getter
 	private ConnectionInPoint dst;
 	@Getter
@@ -46,7 +46,7 @@ public class Belt extends BaseModel implements IConnection, ISuspendable {
 	}
 
 	private void initItems() {
-		items = Stream.generate(() -> new ModelItem(slotsCount - 1)).limit(slotsCount)
+		items = Stream.generate(() -> new ItemCarriage(slotsCount - 1)).limit(slotsCount)
 				.collect(Collectors.toList());
 	}
 
@@ -83,7 +83,7 @@ public class Belt extends BaseModel implements IConnection, ISuspendable {
 		return slotsCount;
 	}
 
-	public List<ModelItem> getItemModels() {
+	public List<ItemCarriage> getItemModels() {
 		return items;
 	}
 

--- a/src/main/java/com/hikari/hellofx/entity/model/belt/Belt.java
+++ b/src/main/java/com/hikari/hellofx/entity/model/belt/Belt.java
@@ -90,7 +90,7 @@ public class Belt extends BaseModel implements IConnection, ISuspendable {
 
 	@Override
 	public void markDetached() {
-		log.info("got detached");
+		//TODO disconnect from other end 
 		isDetached = true;
 	}
 

--- a/src/main/java/com/hikari/hellofx/entity/model/belt/Belt.java
+++ b/src/main/java/com/hikari/hellofx/entity/model/belt/Belt.java
@@ -17,6 +17,7 @@ import lombok.extern.log4j.Log4j2;
 @Log4j2
 public class Belt extends BaseModel implements IConnection, ISuspendable {
 	private static final double CELL_SIZE = 20;
+	private boolean isDetached = false;
 	private static final int CELL_TRAVEL_TIME = 500;
 
 	private int slotsCount;
@@ -85,6 +86,17 @@ public class Belt extends BaseModel implements IConnection, ISuspendable {
 
 	public List<ItemCarriage> getItemModels() {
 		return items;
+	}
+
+	@Override
+	public void markDetached() {
+		log.info("got detached");
+		isDetached = true;
+	}
+
+	@Override
+	public boolean isDetached() {
+		return isDetached;
 	}
 
 }

--- a/src/main/java/com/hikari/hellofx/entity/model/belt/Belt.java
+++ b/src/main/java/com/hikari/hellofx/entity/model/belt/Belt.java
@@ -29,9 +29,7 @@ public class Belt extends BasicConnectionModel {
 
 	public Belt(ConnectionOutPoint source, ConnectionInPoint destination) {
 		connectDestination(destination);
-		destination.connect(this);
 		connectSource(source);
-		source.connect(this);
 		initDistance();
 		initItems();
 		notifySubs(); // for constructing & subbing carts
@@ -52,6 +50,7 @@ public class Belt extends BasicConnectionModel {
 	@Override
 	public void connectDestination(ConnectionInPoint o) {
 		dst = o;
+		o.connect(this);
 	}
 
 	public void connectSource(ConnectionOutPoint o) {

--- a/src/main/java/com/hikari/hellofx/entity/model/belt/Belt.java
+++ b/src/main/java/com/hikari/hellofx/entity/model/belt/Belt.java
@@ -4,22 +4,20 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import com.hikari.hellofx.base.BaseModel;
-import com.hikari.hellofx.entity.IConnection;
-import com.hikari.hellofx.entity.ISuspendable;
-import com.hikari.hellofx.entity.model.ConnectionInPoint;
-import com.hikari.hellofx.entity.model.ConnectionOutPoint;
+import com.hikari.hellofx.entity.model.basic.BasicConnectionModel;
+import com.hikari.hellofx.entity.model.cpoint.ConnectionInPoint;
+import com.hikari.hellofx.entity.model.cpoint.ConnectionOutPoint;
 
 import javafx.geometry.Point2D;
 import lombok.Getter;
 import lombok.extern.log4j.Log4j2;
 
 @Log4j2
-public class Belt extends BaseModel implements IConnection, ISuspendable {
+public class Belt extends BasicConnectionModel {
 	private static final double CELL_SIZE = 20;
-	private boolean isDetached = false;
 	private static final int CELL_TRAVEL_TIME = 500;
 
+	@Getter
 	private int slotsCount;
 
 	// 0 .. slotsCount - 1
@@ -47,23 +45,8 @@ public class Belt extends BaseModel implements IConnection, ISuspendable {
 	}
 
 	private void initItems() {
-		items = Stream.generate(() -> new ItemCarriage(slotsCount - 1)).limit(slotsCount)
-				.collect(Collectors.toList());
-	}
-
-	@Override
-	public void turnOff() {
-		//always on
-	}
-
-	@Override
-	public void turnOn() {
-		//always on
-	}
-
-	@Override
-	public boolean isOn() {
-		return true;
+		items = Stream.generate(() -> new ItemCarriage(slotsCount - 1))
+				.limit(slotsCount).collect(Collectors.toList());
 	}
 
 	@Override
@@ -80,23 +63,8 @@ public class Belt extends BaseModel implements IConnection, ISuspendable {
 		return CELL_TRAVEL_TIME;
 	}
 
-	public double getSlotsCount() {
-		return slotsCount;
-	}
-
 	public List<ItemCarriage> getItemModels() {
 		return items;
-	}
-
-	@Override
-	public void markDetached() {
-		//TODO disconnect from other end 
-		isDetached = true;
-	}
-
-	@Override
-	public boolean isDetached() {
-		return isDetached;
 	}
 
 }

--- a/src/main/java/com/hikari/hellofx/entity/model/belt/ItemCarriage.java
+++ b/src/main/java/com/hikari/hellofx/entity/model/belt/ItemCarriage.java
@@ -1,15 +1,16 @@
 package com.hikari.hellofx.entity.model.belt;
 
 import com.hikari.hellofx.base.BaseModel;
+import com.hikari.hellofx.entity.Item;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 
 @Log4j2
 @RequiredArgsConstructor
-public class ModelItem extends BaseModel{
+public class ItemCarriage extends BaseModel{
 	
-	private Object payload;
+	private Item payload;
 	private int position = 0;
 	private final int maxPosition;
 	//IDLE is not really used..
@@ -32,7 +33,7 @@ public class ModelItem extends BaseModel{
 		return (position != maxPosition);
 	}
 	
-	public boolean notClosePredecessorTo(ModelItem item) {
+	public boolean notClosePredecessorTo(ItemCarriage item) {
 		return position < item.getPosition() - 1;
 	}
 
@@ -45,14 +46,18 @@ public class ModelItem extends BaseModel{
 		return status;
 	}
 	
-	public void putItem(Object o) {
+	public void putItem(Item o) {
 		payload = o;
 	}
 	
-	public Object removeItem() {
-		Object result = payload;
+	public Item removeItem() {
+		Item result = payload;
 		payload = null;
 		return result;
+	}
+	
+	public Item peekItem() {
+		return payload;
 	}
 		
 	public String getPayloadName() {

--- a/src/main/java/com/hikari/hellofx/entity/model/conveyor/Conveyor.java
+++ b/src/main/java/com/hikari/hellofx/entity/model/conveyor/Conveyor.java
@@ -76,6 +76,7 @@ public class Conveyor extends BaseModel implements IConnection, ISuspendable {
 
 	@Override
 	public void markDetached() {
+		// TODO look in BeltService
 		isDetached = true;
 	}
 

--- a/src/main/java/com/hikari/hellofx/entity/model/conveyor/Conveyor.java
+++ b/src/main/java/com/hikari/hellofx/entity/model/conveyor/Conveyor.java
@@ -9,6 +9,7 @@ import com.hikari.hellofx.entity.model.ConnectionInPoint;
 import com.hikari.hellofx.entity.model.ConnectionOutPoint;
 
 import lombok.Getter;
+import lombok.Setter;
 
 public class Conveyor extends BaseModel implements IConnection, ISuspendable {
 	private static final int EVENTS_SIZE = 10;
@@ -16,11 +17,13 @@ public class Conveyor extends BaseModel implements IConnection, ISuspendable {
 	private ConnectionInPoint dst;
 	@Getter
 	private ConnectionOutPoint src;
+	@Getter
+	@Setter
+	private Object payload = null;
 	private static final int TRAVEL_TIME = 1000;
 	private ArrayBlockingQueue<ConnectionEvent> events = new ArrayBlockingQueue<ConnectionEvent>(EVENTS_SIZE);
 
 	public Conveyor() {
-		// lolwhat
 	}
 
 	public Conveyor(ConnectionOutPoint source, ConnectionInPoint destination) {

--- a/src/main/java/com/hikari/hellofx/entity/model/conveyor/Conveyor.java
+++ b/src/main/java/com/hikari/hellofx/entity/model/conveyor/Conveyor.java
@@ -2,16 +2,14 @@ package com.hikari.hellofx.entity.model.conveyor;
 
 import java.util.concurrent.ArrayBlockingQueue;
 
-import com.hikari.hellofx.base.BaseModel;
-import com.hikari.hellofx.entity.IConnection;
-import com.hikari.hellofx.entity.ISuspendable;
-import com.hikari.hellofx.entity.model.ConnectionInPoint;
-import com.hikari.hellofx.entity.model.ConnectionOutPoint;
+import com.hikari.hellofx.entity.model.basic.BasicConnectionModel;
+import com.hikari.hellofx.entity.model.cpoint.ConnectionInPoint;
+import com.hikari.hellofx.entity.model.cpoint.ConnectionOutPoint;
 
 import lombok.Getter;
 import lombok.Setter;
 
-public class Conveyor extends BaseModel implements IConnection, ISuspendable {
+public class Conveyor extends BasicConnectionModel {
 	private static final int EVENTS_SIZE = 10;
 	@Getter
 	private ConnectionInPoint dst;
@@ -21,8 +19,7 @@ public class Conveyor extends BaseModel implements IConnection, ISuspendable {
 	@Setter
 	private Object payload = null;
 	private static final int TRAVEL_TIME = 1000;
-	private ArrayBlockingQueue<ConnectionEvent> events = new ArrayBlockingQueue<ConnectionEvent>(EVENTS_SIZE);
-	private boolean isDetached;
+	private ArrayBlockingQueue<ConnectionEvent> events = new ArrayBlockingQueue<>(EVENTS_SIZE);
 
 	public Conveyor() {
 	}
@@ -33,22 +30,7 @@ public class Conveyor extends BaseModel implements IConnection, ISuspendable {
 		connectSource(source);
 		source.connect(this);
 	}
-
-	@Override
-	public void turnOff() {
-		// always on
-	}
-
-	@Override
-	public void turnOn() {
-		// always on
-	}
-
-	@Override
-	public boolean isOn() {
-		return true;
-	}
-
+	
 	@Override
 	public void connectDestination(ConnectionInPoint o) {
 		dst = o;
@@ -72,17 +54,6 @@ public class Conveyor extends BaseModel implements IConnection, ISuspendable {
 
 	public void addEvent(ConnectionEvent event) {
 		events.add(event);
-	}
-
-	@Override
-	public void markDetached() {
-		// TODO look in BeltService
-		isDetached = true;
-	}
-
-	@Override
-	public boolean isDetached() {
-		return isDetached;
 	}
 
 }

--- a/src/main/java/com/hikari/hellofx/entity/model/conveyor/Conveyor.java
+++ b/src/main/java/com/hikari/hellofx/entity/model/conveyor/Conveyor.java
@@ -22,6 +22,7 @@ public class Conveyor extends BaseModel implements IConnection, ISuspendable {
 	private Object payload = null;
 	private static final int TRAVEL_TIME = 1000;
 	private ArrayBlockingQueue<ConnectionEvent> events = new ArrayBlockingQueue<ConnectionEvent>(EVENTS_SIZE);
+	private boolean isDetached;
 
 	public Conveyor() {
 	}
@@ -71,6 +72,16 @@ public class Conveyor extends BaseModel implements IConnection, ISuspendable {
 
 	public void addEvent(ConnectionEvent event) {
 		events.add(event);
+	}
+
+	@Override
+	public void markDetached() {
+		isDetached = true;
+	}
+
+	@Override
+	public boolean isDetached() {
+		return isDetached;
 	}
 
 }

--- a/src/main/java/com/hikari/hellofx/entity/model/conveyor/Conveyor.java
+++ b/src/main/java/com/hikari/hellofx/entity/model/conveyor/Conveyor.java
@@ -26,18 +26,19 @@ public class Conveyor extends BasicConnectionModel {
 
 	public Conveyor(ConnectionOutPoint source, ConnectionInPoint destination) {
 		connectDestination(destination);
-		destination.connect(this);
 		connectSource(source);
-		source.connect(this);
 	}
-	
+
 	@Override
 	public void connectDestination(ConnectionInPoint o) {
 		dst = o;
+		o.connect(this);
 	}
 
+	@Override
 	public void connectSource(ConnectionOutPoint o) {
 		src = o;
+		o.connect(this);
 	}
 
 	public long getTravelTime() {

--- a/src/main/java/com/hikari/hellofx/entity/model/cpoint/ConnectionInPoint.java
+++ b/src/main/java/com/hikari/hellofx/entity/model/cpoint/ConnectionInPoint.java
@@ -1,4 +1,4 @@
-package com.hikari.hellofx.entity.model;
+package com.hikari.hellofx.entity.model.cpoint;
 
 import com.hikari.hellofx.entity.IServiceNotifier;
 

--- a/src/main/java/com/hikari/hellofx/entity/model/cpoint/ConnectionInPoint.java
+++ b/src/main/java/com/hikari/hellofx/entity/model/cpoint/ConnectionInPoint.java
@@ -1,9 +1,25 @@
 package com.hikari.hellofx.entity.model.cpoint;
 
 import com.hikari.hellofx.entity.IServiceNotifier;
+import com.hikari.hellofx.entity.Item;
 
-public class ConnectionInPoint extends ConnectionPoint{
+public class ConnectionInPoint extends ConnectionPoint {
 	public ConnectionInPoint(IServiceNotifier entity, Double offsetX, Double offsetY) {
 		super(entity, offsetX, offsetY);
+	}
+
+	@Override
+	public void put(Item o) throws InterruptedException {
+		super.put(o);
+		notifyParentService();
+	}
+
+	@Override
+	public boolean offer(Item o) {
+		var res = super.offer(o);
+		if (res) {
+			notifyParentService();
+		}
+		return res;
 	}
 }

--- a/src/main/java/com/hikari/hellofx/entity/model/cpoint/ConnectionOutPoint.java
+++ b/src/main/java/com/hikari/hellofx/entity/model/cpoint/ConnectionOutPoint.java
@@ -1,9 +1,26 @@
 package com.hikari.hellofx.entity.model.cpoint;
 
 import com.hikari.hellofx.entity.IServiceNotifier;
+import com.hikari.hellofx.entity.Item;
 
-public class ConnectionOutPoint extends ConnectionPoint{
+public class ConnectionOutPoint extends ConnectionPoint {
 	public ConnectionOutPoint(IServiceNotifier entity, Double offsetX, Double offsetY) {
 		super(entity, offsetX, offsetY);
+	}
+
+	@Override
+	public Item get() throws InterruptedException {
+		var res = super.get();
+		notifyParentService();
+		return res;
+	}
+
+	@Override
+	public Item poll() {
+		var res = super.poll();
+		if (res != null) {
+			notifyParentService();
+		}
+		return res;
 	}
 }

--- a/src/main/java/com/hikari/hellofx/entity/model/cpoint/ConnectionOutPoint.java
+++ b/src/main/java/com/hikari/hellofx/entity/model/cpoint/ConnectionOutPoint.java
@@ -1,4 +1,4 @@
-package com.hikari.hellofx.entity.model;
+package com.hikari.hellofx.entity.model.cpoint;
 
 import com.hikari.hellofx.entity.IServiceNotifier;
 

--- a/src/main/java/com/hikari/hellofx/entity/model/cpoint/ConnectionPoint.java
+++ b/src/main/java/com/hikari/hellofx/entity/model/cpoint/ConnectionPoint.java
@@ -42,11 +42,9 @@ public class ConnectionPoint extends BaseModel {
 		return (connection == null);
 	}
 
-	private void notifyParentService() {
-		synchronized (parentEntity) {
-			log.info("notifying " + parentEntity.toString());
-			parentEntity.notifyService();
-		}
+	protected void notifyParentService() {
+		log.info("notifying " + parentEntity.toString());
+		parentEntity.notifyService();
 	}
 
 	public void connect(IConnection connection) {
@@ -82,7 +80,6 @@ public class ConnectionPoint extends BaseModel {
 		heldObject = o;
 		log.debug(" taking " + heldObject.toString());
 		isFull.release();
-		notifyParentService();
 	}
 
 	public boolean offer(Item o) {
@@ -93,7 +90,6 @@ public class ConnectionPoint extends BaseModel {
 			heldObject = o;
 			isFull.release();
 			log.debug(" +offered " + heldObject.toString());
-			notifyParentService();
 			return true;
 		}
 	}
@@ -106,7 +102,6 @@ public class ConnectionPoint extends BaseModel {
 			log.debug(" +polled " + heldObject.toString());
 			var res = heldObject;
 			heldObject = null;
-			notifyParentService();
 			isEmpty.release();
 			return res;
 		}

--- a/src/main/java/com/hikari/hellofx/entity/model/cpoint/ConnectionPoint.java
+++ b/src/main/java/com/hikari/hellofx/entity/model/cpoint/ConnectionPoint.java
@@ -22,7 +22,7 @@ public class ConnectionPoint extends BaseModel {
 	@Getter
 	private double lastViewX;
 	@Getter
-	private double lastViewY; 
+	private double lastViewY;
 	@Getter
 	private IConnection connection = null;
 	private final IServiceNotifier parentEntity;
@@ -42,8 +42,12 @@ public class ConnectionPoint extends BaseModel {
 		return (connection == null);
 	}
 
+	public boolean isEmpty() {
+		return (heldObject == null);
+	}
+
 	protected void notifyParentService() {
-		log.info("notifying " + parentEntity.toString());
+		log.trace("notifying " + parentEntity.toString());
 		parentEntity.notifyService();
 	}
 
@@ -106,12 +110,12 @@ public class ConnectionPoint extends BaseModel {
 			return res;
 		}
 	}
-	
-	//this two for preventing self-connecting with spawner
+
+	// this two for preventing self-connecting with spawner
 	IServiceNotifier getParentEntity() {
 		return parentEntity;
 	}
-	
+
 	public boolean parentEquals(ConnectionPoint other) {
 		return parentEntity.equals(other.getParentEntity());
 	}

--- a/src/main/java/com/hikari/hellofx/entity/model/cpoint/ConnectionPoint.java
+++ b/src/main/java/com/hikari/hellofx/entity/model/cpoint/ConnectionPoint.java
@@ -24,7 +24,7 @@ public class ConnectionPoint extends BaseModel {
 	@Getter
 	private double lastViewY; 
 	@Getter
-	protected IConnection connection = null;
+	private IConnection connection = null;
 	private final IServiceNotifier parentEntity;
 
 	private static final int INTHREADSCOUNT = 1;
@@ -55,6 +55,7 @@ public class ConnectionPoint extends BaseModel {
 	}
 
 	public void disconnect() {
+		log.info("disconnected");
 		connection = null;
 	}
 

--- a/src/main/java/com/hikari/hellofx/entity/model/cpoint/ConnectionPoint.java
+++ b/src/main/java/com/hikari/hellofx/entity/model/cpoint/ConnectionPoint.java
@@ -1,4 +1,4 @@
-package com.hikari.hellofx.entity.model;
+package com.hikari.hellofx.entity.model.cpoint;
 
 import java.util.concurrent.Semaphore;
 
@@ -32,10 +32,10 @@ public class ConnectionPoint extends BaseModel {
 	private final Semaphore isFull = new Semaphore(0);
 	private Item heldObject = null;
 
-	public ConnectionPoint(IServiceNotifier entity, Double offsetX_, Double offsetY_) {
+	public ConnectionPoint(IServiceNotifier entity, Double offsetX, Double offsetY) {
 		parentEntity = entity;
-		offsetX = offsetX_;
-		offsetY = offsetY_;
+		this.offsetX = offsetX;
+		this.offsetY = offsetY;
 	}
 
 	public boolean isFree() {
@@ -49,8 +49,8 @@ public class ConnectionPoint extends BaseModel {
 		}
 	}
 
-	public void connect(IConnection connection_) {
-		connection = connection_;
+	public void connect(IConnection connection) {
+		this.connection = connection;
 		notifyParentService();
 	}
 
@@ -73,7 +73,6 @@ public class ConnectionPoint extends BaseModel {
 		var res = heldObject;
 		heldObject = null;
 		isEmpty.release();
-		//notifyParent();
 		return res;
 	}
 

--- a/src/main/java/com/hikari/hellofx/entity/service/AssemblerService.java
+++ b/src/main/java/com/hikari/hellofx/entity/service/AssemblerService.java
@@ -27,7 +27,7 @@ public class AssemblerService extends BaseService{
 			model.notifySubs();
 			model.getOut().put(item);
 		}
-		model.setPayload(null);;
+		model.setPayload(null);
 		model.notifySubs();
 	}
 }

--- a/src/main/java/com/hikari/hellofx/entity/service/AssemblerService.java
+++ b/src/main/java/com/hikari/hellofx/entity/service/AssemblerService.java
@@ -2,6 +2,7 @@ package com.hikari.hellofx.entity.service;
 
 import com.hikari.hellofx.base.BaseService;
 import com.hikari.hellofx.entity.ISuspendable;
+import com.hikari.hellofx.entity.Item;
 import com.hikari.hellofx.entity.model.AssemblerModel;
 
 public class AssemblerService extends BaseService{
@@ -18,7 +19,7 @@ public class AssemblerService extends BaseService{
 		var resourceRight = model.getInRight().get();
 		model.notifySubs();
 		sleep(PRODUCTION_TIME);
-		var o = new Object();
+		var o = Item.IRON;
 		model.setPayload(o);
 		model.notifySubs();
 		model.getOut().put(o);

--- a/src/main/java/com/hikari/hellofx/entity/service/AssemblerService.java
+++ b/src/main/java/com/hikari/hellofx/entity/service/AssemblerService.java
@@ -1,8 +1,9 @@
 package com.hikari.hellofx.entity.service;
 
+import java.util.Set;
+
 import com.hikari.hellofx.base.BaseService;
 import com.hikari.hellofx.entity.ISuspendable;
-import com.hikari.hellofx.entity.Item;
 import com.hikari.hellofx.entity.model.AssemblerModel;
 
 public class AssemblerService extends BaseService{
@@ -11,18 +12,21 @@ public class AssemblerService extends BaseService{
 	public AssemblerService(ISuspendable model) {
 		super(model);
 	}
-	@SuppressWarnings("unused")
+	//@SuppressWarnings("unused")
 	protected void performCycle() throws InterruptedException {
 		var model = (AssemblerModel)getModel();
-		var resourceLeft = model.getInLeft().get();
+		var resourceFirst = model.getInLeft().get();
 		model.notifySubs();
-		var resourceRight = model.getInRight().get();
+		var resourceSecond = model.getInRight().get();
 		model.notifySubs();
 		sleep(PRODUCTION_TIME);
-		var o = Item.IRON;
-		model.setPayload(o);
-		model.notifySubs();
-		model.getOut().put(o);
+		var recipe = model.getCurrentRecipe();
+		if(recipe.test(Set.of(resourceFirst, resourceSecond))){
+			var item = recipe.produce();
+			model.setPayload(item);
+			model.notifySubs();
+			model.getOut().put(item);
+		}
 		model.setPayload(null);;
 		model.notifySubs();
 	}

--- a/src/main/java/com/hikari/hellofx/entity/service/BasicConnectionService.java
+++ b/src/main/java/com/hikari/hellofx/entity/service/BasicConnectionService.java
@@ -1,0 +1,43 @@
+package com.hikari.hellofx.entity.service;
+
+import com.hikari.hellofx.base.BaseService;
+import com.hikari.hellofx.entity.ISuspendable;
+import com.hikari.hellofx.entity.model.basic.BasicConnectionModel;
+
+import lombok.extern.log4j.Log4j2;
+
+@Log4j2
+public abstract class BasicConnectionService extends BaseService{
+	
+	protected BasicConnectionService(ISuspendable model) {
+		super(model);
+	}
+
+	@Override
+	public void run() {
+		while (true) {
+			try {
+				selfWait();
+				performCycle();
+			} catch (InterruptedException e) {
+				log.error("Interrupted");
+				checkIfDetached();
+				Thread.currentThread().interrupt();
+				return;
+				//TODO conditional variable? methods for safer stop/start/kill
+			}
+		}
+	}
+	
+	private void checkIfDetached(){
+		if(getModel() instanceof BasicConnectionModel model) {
+			if (model.isDetached()) {
+				log.info("detaching");
+				// TODO here can complete sending left items
+				// but for now just dropping all without excessive offers/polls
+				model.getDst().disconnect();
+				model.getSrc().disconnect();
+			}
+		}
+	}
+}

--- a/src/main/java/com/hikari/hellofx/entity/service/BeltService.java
+++ b/src/main/java/com/hikari/hellofx/entity/service/BeltService.java
@@ -4,8 +4,9 @@ import java.util.stream.Collectors;
 
 import com.hikari.hellofx.base.BaseService;
 import com.hikari.hellofx.entity.ISuspendable;
+import com.hikari.hellofx.entity.Item;
 import com.hikari.hellofx.entity.model.belt.Belt;
-import com.hikari.hellofx.entity.model.belt.ModelItem;
+import com.hikari.hellofx.entity.model.belt.ItemCarriage;
 
 import lombok.extern.log4j.Log4j2;
 
@@ -39,8 +40,8 @@ public class BeltService extends BaseService {
 
 	private void offerItem() {
 		if (haveReadyItems()) {
-			ModelItem current = bModel.getItemModels().get(base);
-			Object o = current.removeItem();
+			ItemCarriage current = bModel.getItemModels().get(base);
+			Item o = current.removeItem();
 			if (bModel.getDst().offer(o)) {
 				base = cycleIncrement(base);
 				current.dispatch();
@@ -53,7 +54,7 @@ public class BeltService extends BaseService {
 
 	private void pollItem() {
 		if (haveEmptySlots()) {
-			Object o = bModel.getSrc().poll();
+			Item o = bModel.getSrc().poll();
 			if (o != null) {
 				bModel.getItemModels().get(end).putItem(o);
 				end = cycleIncrement(end);
@@ -64,13 +65,13 @@ public class BeltService extends BaseService {
 	private void moveCells() {
 		log.debug("base/end: " + base + "/" + end);
 		for (int i = base; i != end; i = cycleIncrement(i)) {
-			ModelItem current = bModel.getItemModels().get(i);
+			ItemCarriage current = bModel.getItemModels().get(i);
 			if ((i == base && current.notEndReached()) || (current.notEndReached()
 					&& current.notClosePredecessorTo(bModel.getItemModels().get(cycleDecrement(i))))) {
 				current.move();
 			}
 		}
-		log.debug(bModel.getItemModels().stream().map(ModelItem::toString).collect(Collectors.joining(",")));
+		log.debug(bModel.getItemModels().stream().map(ItemCarriage::toString).collect(Collectors.joining(",")));
 	}
 
 	private int cycleDecrement(int a) {

--- a/src/main/java/com/hikari/hellofx/entity/service/BeltService.java
+++ b/src/main/java/com/hikari/hellofx/entity/service/BeltService.java
@@ -41,7 +41,6 @@ public class BeltService extends BaseService {
 
 	private void checkIfDetached() throws InterruptedException {
 		if(bModel.isDetached()) {
-			log.info("detaching");
 			// TODO here can complete sending left items
 			// but for now just dropping all without excessive offers/polls
 			bModel.getDst().disconnect();

--- a/src/main/java/com/hikari/hellofx/entity/service/BeltService.java
+++ b/src/main/java/com/hikari/hellofx/entity/service/BeltService.java
@@ -2,7 +2,6 @@ package com.hikari.hellofx.entity.service;
 
 import java.util.stream.Collectors;
 
-import com.hikari.hellofx.base.BaseService;
 import com.hikari.hellofx.entity.ISuspendable;
 import com.hikari.hellofx.entity.Item;
 import com.hikari.hellofx.entity.model.belt.Belt;
@@ -11,7 +10,7 @@ import com.hikari.hellofx.entity.model.belt.ItemCarriage;
 import lombok.extern.log4j.Log4j2;
 
 @Log4j2
-public class BeltService extends BaseService {
+public class BeltService extends BasicConnectionService {
 	private int base = 0;
 	private int end = 0;
 	private Belt bModel;
@@ -35,18 +34,7 @@ public class BeltService extends BaseService {
 		offerItem();
 		moveCells();
 		sleep(bModel.getCellTravelTime());
-		checkIfDetached();
 		pollItem();
-	}
-
-	private void checkIfDetached() throws InterruptedException {
-		if(bModel.isDetached()) {
-			// TODO here can complete sending left items
-			// but for now just dropping all without excessive offers/polls
-			bModel.getDst().disconnect();
-			bModel.getSrc().disconnect();
-			throw new InterruptedException();
-		}
 	}
 
 	private void offerItem() {

--- a/src/main/java/com/hikari/hellofx/entity/service/BeltService.java
+++ b/src/main/java/com/hikari/hellofx/entity/service/BeltService.java
@@ -52,11 +52,10 @@ public class BeltService extends BaseService {
 	private void offerItem() {
 		if (haveReadyItems()) {
 			ItemCarriage current = bModel.getItemModels().get(base);
-			Item o = current.removeItem();
+			var o = current.removeItem();
 			if (bModel.getDst().offer(o)) {
 				base = cycleIncrement(base);
 				current.dispatch();
-				;
 			} else {
 				current.putItem(o);
 			}
@@ -86,11 +85,11 @@ public class BeltService extends BaseService {
 	}
 
 	private int cycleDecrement(int a) {
-		return Math.floorMod(a - 1, (int) bModel.getSlotsCount());
+		return Math.floorMod(a - 1, bModel.getSlotsCount());
 	}
 
 	private int cycleIncrement(int a) {
-		return (a + 1) % (int) bModel.getSlotsCount();
+		return (a + 1) % bModel.getSlotsCount();
 	}
 
 }

--- a/src/main/java/com/hikari/hellofx/entity/service/BeltService.java
+++ b/src/main/java/com/hikari/hellofx/entity/service/BeltService.java
@@ -35,7 +35,19 @@ public class BeltService extends BaseService {
 		offerItem();
 		moveCells();
 		sleep(bModel.getCellTravelTime());
+		checkIfDetached();
 		pollItem();
+	}
+
+	private void checkIfDetached() throws InterruptedException {
+		if(bModel.isDetached()) {
+			log.info("detaching");
+			// TODO here can complete sending left items
+			// but for now just dropping all without excessive offers/polls
+			bModel.getDst().disconnect();
+			bModel.getSrc().disconnect();
+			throw new InterruptedException();
+		}
 	}
 
 	private void offerItem() {

--- a/src/main/java/com/hikari/hellofx/entity/service/ConstructorService.java
+++ b/src/main/java/com/hikari/hellofx/entity/service/ConstructorService.java
@@ -1,5 +1,7 @@
 package com.hikari.hellofx.entity.service;
 
+import java.util.Set;
+
 import com.hikari.hellofx.base.BaseService;
 import com.hikari.hellofx.entity.ISuspendable;
 import com.hikari.hellofx.entity.model.ConstructorModel;
@@ -11,13 +13,18 @@ public class ConstructorService extends BaseService{
 	}
 
 	protected void performCycle() throws InterruptedException {
+		//TODO: for now throwing away all wrong components due to infinite 
+		// mire supply. same in assembler
 		var model = (ConstructorModel)getModel();
 		var o = model.getIn().get();
 		model.setPayload(o);
 		model.notifySubs();
 		sleep(PRODUCTION_TIME);
-		model.getOut().put(o);
-		model.setPayload(o);
+		var recipe = model.getCurrentRecipe();
+		if(recipe.test(Set.of(o))){
+			model.getOut().put(recipe.produce());
+		}
+		model.setPayload(null);
 		model.notifySubs();
 	}
 }

--- a/src/main/java/com/hikari/hellofx/entity/service/ConstructorService.java
+++ b/src/main/java/com/hikari/hellofx/entity/service/ConstructorService.java
@@ -5,7 +5,7 @@ import com.hikari.hellofx.entity.ISuspendable;
 import com.hikari.hellofx.entity.model.ConstructorModel;
 
 public class ConstructorService extends BaseService{
-	private final int PRODUCTION_TIME = 1000;
+	private static final int PRODUCTION_TIME = 1000;
 	public ConstructorService(ISuspendable model) {
 		super(model);
 	}

--- a/src/main/java/com/hikari/hellofx/entity/service/ConveyorService.java
+++ b/src/main/java/com/hikari/hellofx/entity/service/ConveyorService.java
@@ -1,12 +1,11 @@
 package com.hikari.hellofx.entity.service;
 
-import com.hikari.hellofx.base.BaseService;
 import com.hikari.hellofx.entity.ISuspendable;
 import com.hikari.hellofx.entity.Item;
 import com.hikari.hellofx.entity.model.conveyor.ConnectionEvent;
 import com.hikari.hellofx.entity.model.conveyor.Conveyor;
 
-public class ConveyorService extends BaseService {
+public class ConveyorService extends BasicConnectionService {
 	private Conveyor cModel;
 
 	public ConveyorService(ISuspendable model) {
@@ -21,20 +20,10 @@ public class ConveyorService extends BaseService {
 		cModel.setPayload(o);
 		cModel.notifySubs();
 		sleep(cModel.getTravelTime());
-		checkIfDetached();
 		cModel.setPayload(null);
 		cModel.getDst().put(o);
 		cModel.addEvent(ConnectionEvent.ARRIVED);
 		cModel.notifySubs();
 	}
 
-	private void checkIfDetached() throws InterruptedException {
-		if (cModel.isDetached()) {
-			// TODO here can complete sending left items
-			// but for now just dropping all without excessive offers/polls
-			cModel.getDst().disconnect();
-			cModel.getSrc().disconnect();
-			throw new InterruptedException();
-		}
-	}
 }

--- a/src/main/java/com/hikari/hellofx/entity/service/ConveyorService.java
+++ b/src/main/java/com/hikari/hellofx/entity/service/ConveyorService.java
@@ -2,6 +2,7 @@ package com.hikari.hellofx.entity.service;
 
 import com.hikari.hellofx.base.BaseService;
 import com.hikari.hellofx.entity.ISuspendable;
+import com.hikari.hellofx.entity.Item;
 import com.hikari.hellofx.entity.model.conveyor.ConnectionEvent;
 import com.hikari.hellofx.entity.model.conveyor.Conveyor;
 
@@ -15,7 +16,7 @@ public class ConveyorService extends BaseService {
 	@Override
 	protected void performCycle() throws InterruptedException {
 		var model = (Conveyor) getModel();
-		Object o = model.getSrc().get();
+		Item o = model.getSrc().get();
 		model.addEvent(ConnectionEvent.DEPARTED);
 		model.notifySubs();
 		sleep(model.getTravelTime());

--- a/src/main/java/com/hikari/hellofx/entity/service/ConveyorService.java
+++ b/src/main/java/com/hikari/hellofx/entity/service/ConveyorService.java
@@ -18,8 +18,10 @@ public class ConveyorService extends BaseService {
 		var model = (Conveyor) getModel();
 		Item o = model.getSrc().get();
 		model.addEvent(ConnectionEvent.DEPARTED);
+		model.setPayload(o);
 		model.notifySubs();
 		sleep(model.getTravelTime());
+		model.setPayload(null);
 		model.getDst().put(o);
 		model.addEvent(ConnectionEvent.ARRIVED);
 		model.notifySubs();

--- a/src/main/java/com/hikari/hellofx/entity/service/ConveyorService.java
+++ b/src/main/java/com/hikari/hellofx/entity/service/ConveyorService.java
@@ -6,25 +6,35 @@ import com.hikari.hellofx.entity.Item;
 import com.hikari.hellofx.entity.model.conveyor.ConnectionEvent;
 import com.hikari.hellofx.entity.model.conveyor.Conveyor;
 
-
 public class ConveyorService extends BaseService {
+	private Conveyor cModel;
 
 	public ConveyorService(ISuspendable model) {
 		super(model);
+		cModel = (Conveyor) model;
 	}
 
 	@Override
 	protected void performCycle() throws InterruptedException {
-		var model = (Conveyor) getModel();
-		Item o = model.getSrc().get();
-		model.addEvent(ConnectionEvent.DEPARTED);
-		model.setPayload(o);
-		model.notifySubs();
-		sleep(model.getTravelTime());
-		model.setPayload(null);
-		model.getDst().put(o);
-		model.addEvent(ConnectionEvent.ARRIVED);
-		model.notifySubs();
+		Item o = cModel.getSrc().get();
+		cModel.addEvent(ConnectionEvent.DEPARTED);
+		cModel.setPayload(o);
+		cModel.notifySubs();
+		sleep(cModel.getTravelTime());
+		checkIfDetached();
+		cModel.setPayload(null);
+		cModel.getDst().put(o);
+		cModel.addEvent(ConnectionEvent.ARRIVED);
+		cModel.notifySubs();
 	}
 
+	private void checkIfDetached() throws InterruptedException {
+		if (cModel.isDetached()) {
+			// TODO here can complete sending left items
+			// but for now just dropping all without excessive offers/polls
+			cModel.getDst().disconnect();
+			cModel.getSrc().disconnect();
+			throw new InterruptedException();
+		}
+	}
 }

--- a/src/main/java/com/hikari/hellofx/entity/service/MergerService.java
+++ b/src/main/java/com/hikari/hellofx/entity/service/MergerService.java
@@ -55,11 +55,8 @@ public class MergerService extends BaseService{
 		var model = (MergerModel)getModel();
 		var amount = model.amountOfConnectedPoints();
 		if (amount == 0) {
-			log.info("zzz");
 			selfWait();
-			log.info("awaken1");
 		} else {
-			// TODO what about disconnects?
 			for (var i = 0; i < amount; i++) {
 				commutateOneObject(model);
 			}

--- a/src/main/java/com/hikari/hellofx/entity/service/MergerService.java
+++ b/src/main/java/com/hikari/hellofx/entity/service/MergerService.java
@@ -5,8 +5,8 @@ import java.util.List;
 import com.hikari.hellofx.base.BaseService;
 import com.hikari.hellofx.entity.ISuspendable;
 import com.hikari.hellofx.entity.Item;
-import com.hikari.hellofx.entity.model.ConnectionInPoint;
 import com.hikari.hellofx.entity.model.MergerModel;
+import com.hikari.hellofx.entity.model.cpoint.ConnectionInPoint;
 
 import lombok.extern.log4j.Log4j2;
 

--- a/src/main/java/com/hikari/hellofx/entity/service/MergerService.java
+++ b/src/main/java/com/hikari/hellofx/entity/service/MergerService.java
@@ -1,0 +1,59 @@
+package com.hikari.hellofx.entity.service;
+
+import java.util.List;
+
+import com.hikari.hellofx.base.BaseService;
+import com.hikari.hellofx.entity.ISuspendable;
+import com.hikari.hellofx.entity.model.ConnectionInPoint;
+import com.hikari.hellofx.entity.model.MergerModel;
+
+import lombok.extern.log4j.Log4j2;
+
+@Log4j2
+public class MergerService extends BaseService{
+	private static final int BLOCKED_POINTS_TRUST_AMOUNT = 4;
+	public MergerService(ISuspendable model) {
+		super(model);
+	}
+	
+	private Object pollOneObject(List<ConnectionInPoint> ins) throws InterruptedException {
+		Object o;
+		var trust = BLOCKED_POINTS_TRUST_AMOUNT;
+		for (;;) {
+			for (ConnectionInPoint p : ins) {
+				if (!p.isFree() && (o = p.poll()) != null) {
+					return o;
+				}
+			}
+			trust--;
+			if (trust == 0) {
+				trust = BLOCKED_POINTS_TRUST_AMOUNT;
+				// go wait for someone to connect/ become free
+				log.info("zzz");
+				selfWait();
+				log.info("awaken2");
+			}
+		}
+	}
+	
+	private void commutateOneObject(MergerModel model) throws InterruptedException {
+		Object o = pollOneObject(model.getIns());
+		model.getOut().put(o);
+		model.notifySubs();
+	}
+
+	protected void performCycle() throws InterruptedException {
+		var model = (MergerModel)getModel();
+		var amount = model.amountOfConnectedPoints();
+		if (amount == 0) {
+			log.info("zzz");
+			selfWait();
+			log.info("awaken1");
+		} else {
+			// TODO what about disconnects?
+			for (var i = 0; i < amount; i++) {
+				commutateOneObject(model);
+			}
+		}
+	}
+}

--- a/src/main/java/com/hikari/hellofx/entity/service/MergerService.java
+++ b/src/main/java/com/hikari/hellofx/entity/service/MergerService.java
@@ -7,60 +7,28 @@ import com.hikari.hellofx.entity.ISuspendable;
 import com.hikari.hellofx.entity.Item;
 import com.hikari.hellofx.entity.model.MergerModel;
 import com.hikari.hellofx.entity.model.cpoint.ConnectionInPoint;
+import com.hikari.hellofx.entity.model.cpoint.ConnectionPoint;
 
-import lombok.extern.log4j.Log4j2;
-
-@Log4j2
 public class MergerService extends BaseService{
-	private static final int BLOCKED_POINTS_TRUST_AMOUNT = 4;
-	private int lastPolledIndex = 0;
 	public MergerService(ISuspendable model) {
 		super(model);
 	}
 	
-	private Item pollNewObject(List<ConnectionInPoint> ins) throws InterruptedException {
+	private void commutate(MergerModel model, List<ConnectionPoint> list) throws InterruptedException {
 		Item o;
-		var trust = BLOCKED_POINTS_TRUST_AMOUNT;
-		for (;;) {
-			for (int i = cycleIndex(lastPolledIndex, ins.size()), j = 0;
-					j < ins.size() ;
-					i = cycleIndex(i, ins.size()), j++) {
-				if (!ins.get(i).isFree() && (o = ins.get(i).poll()) != null) {
-					lastPolledIndex = (lastPolledIndex + i) % ins.size();
-					return o;
-				}
+		for(ConnectionPoint p : list) {
+			if((o = p.poll()) != null) {
+				model.getOut().put(o);
+				model.notifySubs();
 			}
-			trust--;
-			if (trust == 0) {
-				trust = BLOCKED_POINTS_TRUST_AMOUNT;
-				// go wait for someone to connect/ become free
-				//TODO DOESNT WORK ACTUALLY
-				log.info("zzz");
-				selfWait();
-				log.info("awaken2");
-			}
-		}
-	}
-	
-	private int cycleIndex(int i, int l) {
-		return (i + 1) % l;
-	}
-	
-	private void commutateOneObject(MergerModel model) throws InterruptedException {
-		Item o = pollNewObject(model.getIns());
-		model.getOut().put(o);
-		model.notifySubs();
+		}		
 	}
 
 	protected void performCycle() throws InterruptedException {
-		var model = (MergerModel)getModel();
-		var amount = model.amountOfConnectedPoints();
-		if (amount == 0) {
-			selfWait();
-		} else {
-			for (var i = 0; i < amount; i++) {
-				commutateOneObject(model);
-			}
+		var model = (MergerModel) getModel();
+		var list = model.filterPoints(ConnectionInPoint.class, (p -> (!p.isFree()) && (!p.isEmpty())));
+		if (!list.isEmpty()) {
+			commutate(model, list);
 		}
 	}
 }

--- a/src/main/java/com/hikari/hellofx/entity/service/MergerService.java
+++ b/src/main/java/com/hikari/hellofx/entity/service/MergerService.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import com.hikari.hellofx.base.BaseService;
 import com.hikari.hellofx.entity.ISuspendable;
+import com.hikari.hellofx.entity.Item;
 import com.hikari.hellofx.entity.model.ConnectionInPoint;
 import com.hikari.hellofx.entity.model.MergerModel;
 
@@ -16,9 +17,9 @@ public class MergerService extends BaseService{
 		super(model);
 	}
 	
-	private Object pollOneObject(List<ConnectionInPoint> ins) throws InterruptedException {
+	private Item pollOneObject(List<ConnectionInPoint> ins) throws InterruptedException {
 		//TODO actually works wrong, prefers first point istead of full loop. rework.
-		Object o;
+		Item o;
 		var trust = BLOCKED_POINTS_TRUST_AMOUNT;
 		for (;;) {
 			for (ConnectionInPoint p : ins) {
@@ -38,7 +39,7 @@ public class MergerService extends BaseService{
 	}
 	
 	private void commutateOneObject(MergerModel model) throws InterruptedException {
-		Object o = pollOneObject(model.getIns());
+		Item o = pollOneObject(model.getIns());
 		model.getOut().put(o);
 		model.notifySubs();
 	}

--- a/src/main/java/com/hikari/hellofx/entity/service/MergerService.java
+++ b/src/main/java/com/hikari/hellofx/entity/service/MergerService.java
@@ -34,6 +34,7 @@ public class MergerService extends BaseService{
 			if (trust == 0) {
 				trust = BLOCKED_POINTS_TRUST_AMOUNT;
 				// go wait for someone to connect/ become free
+				//TODO DOESNT WORK ACTUALLY
 				log.info("zzz");
 				selfWait();
 				log.info("awaken2");

--- a/src/main/java/com/hikari/hellofx/entity/service/MergerService.java
+++ b/src/main/java/com/hikari/hellofx/entity/service/MergerService.java
@@ -17,6 +17,7 @@ public class MergerService extends BaseService{
 	}
 	
 	private Object pollOneObject(List<ConnectionInPoint> ins) throws InterruptedException {
+		//TODO actually works wrong, prefers first point istead of full loop. rework.
 		Object o;
 		var trust = BLOCKED_POINTS_TRUST_AMOUNT;
 		for (;;) {

--- a/src/main/java/com/hikari/hellofx/entity/service/MinerService.java
+++ b/src/main/java/com/hikari/hellofx/entity/service/MinerService.java
@@ -18,7 +18,7 @@ public class MinerService extends BaseService{
 		model.setPayload(o);
 		model.notifySubs();
 		model.getOut().put(o);
-		model.setPayload(o);
+		model.setPayload(null);
 		model.notifySubs();
 	}
 	

--- a/src/main/java/com/hikari/hellofx/entity/service/MinerService.java
+++ b/src/main/java/com/hikari/hellofx/entity/service/MinerService.java
@@ -14,7 +14,7 @@ public class MinerService extends BaseService{
 	protected void performCycle() throws InterruptedException {
 		var model = (MinerModel)getModel();
 		sleep(PRODUCTION_TIME);
-		var o = new Object();
+		var o = model.getCurrentRecipe().produce();
 		model.setPayload(o);
 		model.notifySubs();
 		model.getOut().put(o);

--- a/src/main/java/com/hikari/hellofx/entity/service/SplitterService.java
+++ b/src/main/java/com/hikari/hellofx/entity/service/SplitterService.java
@@ -3,8 +3,8 @@ package com.hikari.hellofx.entity.service;
 import com.hikari.hellofx.base.BaseService;
 import com.hikari.hellofx.entity.ISuspendable;
 import com.hikari.hellofx.entity.Item;
-import com.hikari.hellofx.entity.model.ConnectionOutPoint;
 import com.hikari.hellofx.entity.model.SplitterModel;
+import com.hikari.hellofx.entity.model.cpoint.ConnectionOutPoint;
 
 import lombok.extern.log4j.Log4j2;
 

--- a/src/main/java/com/hikari/hellofx/entity/service/SplitterService.java
+++ b/src/main/java/com/hikari/hellofx/entity/service/SplitterService.java
@@ -2,6 +2,7 @@ package com.hikari.hellofx.entity.service;
 
 import com.hikari.hellofx.base.BaseService;
 import com.hikari.hellofx.entity.ISuspendable;
+import com.hikari.hellofx.entity.Item;
 import com.hikari.hellofx.entity.model.ConnectionOutPoint;
 import com.hikari.hellofx.entity.model.SplitterModel;
 
@@ -15,7 +16,7 @@ public class SplitterService extends BaseService{
 	}
 	
 	private void commutateOneObject(SplitterModel model) throws InterruptedException {
-		Object o;
+		Item o;
 		var trust = BLOCKED_POINTS_TRUST_AMOUNT;
 		o = model.getIn().get();
 		model.notifySubs();

--- a/src/main/java/com/hikari/hellofx/entity/service/SplitterService.java
+++ b/src/main/java/com/hikari/hellofx/entity/service/SplitterService.java
@@ -1,54 +1,37 @@
 package com.hikari.hellofx.entity.service;
 
+import java.util.List;
+
 import com.hikari.hellofx.base.BaseService;
 import com.hikari.hellofx.entity.ISuspendable;
 import com.hikari.hellofx.entity.Item;
 import com.hikari.hellofx.entity.model.SplitterModel;
 import com.hikari.hellofx.entity.model.cpoint.ConnectionOutPoint;
+import com.hikari.hellofx.entity.model.cpoint.ConnectionPoint;
 
-import lombok.extern.log4j.Log4j2;
+public class SplitterService extends BaseService {
+	private Item heldItem = null;
 
-@Log4j2
-public class SplitterService extends BaseService{
-	private static final int BLOCKED_POINTS_TRUST_AMOUNT = 4;
 	public SplitterService(ISuspendable model) {
 		super(model);
 	}
-	
-	private void commutateOneObject(SplitterModel model) throws InterruptedException {
-		Item o;
-		var trust = BLOCKED_POINTS_TRUST_AMOUNT;
-		o = model.getIn().get();
-		model.notifySubs();
-		for (;;) {
-			for (ConnectionOutPoint p : model.getOuts()) {
-				if (!p.isFree() && p.offer(o)) {
-					return;
-				}
+
+	private void commutate(SplitterModel model, List<ConnectionPoint> list) throws InterruptedException {
+		for (ConnectionPoint p : list) {
+			if (heldItem == null) {
+				heldItem = model.getIn().get();
 			}
-			trust--;
-			if (trust == 0) {
-				trust = BLOCKED_POINTS_TRUST_AMOUNT;
-				// go wait for someone to connect/ become free
-				log.info("zzz");
-				selfWait();
-				log.info("awaken2");
+			if (p.offer(heldItem)) {
+				heldItem = null;
 			}
 		}
 	}
 
 	protected void performCycle() throws InterruptedException {
-		var model = (SplitterModel)getModel();
-		var amount = model.amountOfConnectedPoints();
-		if (amount == 0) {
-			log.info("zzz");
-			selfWait();
-			log.info("awaken1");
-		} else {
-			// TODO what about disconnects?
-			for (var i = 0; i < amount; i++) {
-				commutateOneObject(model);
-			}
+		var model = (SplitterModel) getModel();
+		var list = model.filterPoints(ConnectionOutPoint.class, (p -> (!p.isFree()) && p.isEmpty()));
+		if (!list.isEmpty()) {
+			commutate(model, list);
 		}
 	}
 }

--- a/src/main/java/com/hikari/hellofx/entity/service/StorageService.java
+++ b/src/main/java/com/hikari/hellofx/entity/service/StorageService.java
@@ -2,6 +2,7 @@ package com.hikari.hellofx.entity.service;
 
 import com.hikari.hellofx.base.BaseService;
 import com.hikari.hellofx.entity.ISuspendable;
+import com.hikari.hellofx.entity.Item;
 import com.hikari.hellofx.entity.model.StorageModel;
 
 public class StorageService extends BaseService{
@@ -12,8 +13,8 @@ public class StorageService extends BaseService{
 
 	protected void performCycle() throws InterruptedException {
 		var model = (StorageModel)getModel();	
-		Object o = model.getIn().get();
-		model.getStorage().add(o);
+		Item o = model.getIn().get();
+		model.addItem(o);
 		model.notifySubs();
 	}
 }

--- a/src/main/java/com/hikari/hellofx/entity/service/connection/BasicConnectionService.java
+++ b/src/main/java/com/hikari/hellofx/entity/service/connection/BasicConnectionService.java
@@ -1,4 +1,4 @@
-package com.hikari.hellofx.entity.service;
+package com.hikari.hellofx.entity.service.connection;
 
 import com.hikari.hellofx.base.BaseService;
 import com.hikari.hellofx.entity.ISuspendable;
@@ -17,7 +17,6 @@ public abstract class BasicConnectionService extends BaseService{
 	public void run() {
 		while (true) {
 			try {
-				selfWait();
 				performCycle();
 			} catch (InterruptedException e) {
 				log.error("Interrupted");

--- a/src/main/java/com/hikari/hellofx/entity/service/connection/BeltService.java
+++ b/src/main/java/com/hikari/hellofx/entity/service/connection/BeltService.java
@@ -1,4 +1,4 @@
-package com.hikari.hellofx.entity.service;
+package com.hikari.hellofx.entity.service.connection;
 
 import java.util.stream.Collectors;
 

--- a/src/main/java/com/hikari/hellofx/entity/service/connection/ConveyorService.java
+++ b/src/main/java/com/hikari/hellofx/entity/service/connection/ConveyorService.java
@@ -1,4 +1,4 @@
-package com.hikari.hellofx.entity.service;
+package com.hikari.hellofx.entity.service.connection;
 
 import com.hikari.hellofx.entity.ISuspendable;
 import com.hikari.hellofx.entity.Item;

--- a/src/main/java/com/hikari/hellofx/entity/view/BasicEntityView.java
+++ b/src/main/java/com/hikari/hellofx/entity/view/BasicEntityView.java
@@ -7,9 +7,9 @@ import com.hikari.hellofx.base.IModelSubscriber;
 import com.hikari.hellofx.entity.BindingController;
 import com.hikari.hellofx.entity.IConnectable;
 import com.hikari.hellofx.entity.ISuspendable;
-import com.hikari.hellofx.entity.model.ConnectionInPoint;
-import com.hikari.hellofx.entity.model.ConnectionOutPoint;
-import com.hikari.hellofx.entity.model.ConnectionPoint;
+import com.hikari.hellofx.entity.model.cpoint.ConnectionInPoint;
+import com.hikari.hellofx.entity.model.cpoint.ConnectionOutPoint;
+import com.hikari.hellofx.entity.model.cpoint.ConnectionPoint;
 import com.hikari.hellofx.game.GameAction;
 import com.hikari.hellofx.game.control.BareAction;
 

--- a/src/main/java/com/hikari/hellofx/entity/view/BasicEntityView.java
+++ b/src/main/java/com/hikari/hellofx/entity/view/BasicEntityView.java
@@ -7,6 +7,8 @@ import com.hikari.hellofx.base.IModelSubscriber;
 import com.hikari.hellofx.entity.BindingController;
 import com.hikari.hellofx.entity.IConnectable;
 import com.hikari.hellofx.entity.ISuspendable;
+import com.hikari.hellofx.entity.model.ConnectionInPoint;
+import com.hikari.hellofx.entity.model.ConnectionOutPoint;
 import com.hikari.hellofx.entity.model.ConnectionPoint;
 import com.hikari.hellofx.game.GameAction;
 import com.hikari.hellofx.game.control.BareAction;
@@ -48,10 +50,10 @@ public class BasicEntityView extends Pane implements IModelSubscriber {
 		clearChildren();
 		switch (state) {
 		case IN_POINTS:
-			showPoints(cModel.getInPoints());
+			showPoints(cModel.filterFreePoints(ConnectionInPoint.class));
 			break;
 		case OUT_POINTS:
-			showPoints(cModel.getOutPoints());
+			showPoints(cModel.filterFreePoints(ConnectionOutPoint.class));
 			break;
 		case NO_POINTS:
 			break;

--- a/src/main/java/com/hikari/hellofx/entity/view/BasicEntityView.java
+++ b/src/main/java/com/hikari/hellofx/entity/view/BasicEntityView.java
@@ -1,5 +1,6 @@
 package com.hikari.hellofx.entity.view;
 
+import java.util.Collections;
 import java.util.List;
 
 import com.hikari.hellofx.base.BaseModel;
@@ -39,6 +40,7 @@ public class BasicEntityView extends Pane implements IModelSubscriber {
 		if (model instanceof IConnectable cModel) {
 			String labelText = checkPower(cModel) + " " + checkFill(cModel);
 			Platform.runLater(() -> {
+				shapePane.renderSlices(generateSlices(cModel));
 				shapePane.getLabel().setText(labelText);
 				showPoints(cModel);
 			});
@@ -89,5 +91,10 @@ public class BasicEntityView extends Pane implements IModelSubscriber {
 
 	private String checkFill(IConnectable model) {
 		return model.getFillCount().toString();
+	}
+	
+	protected List<Slice> generateSlices(IConnectable model) {
+		//for overriding in views working with shape
+		return Collections.emptyList();
 	}
 }

--- a/src/main/java/com/hikari/hellofx/entity/view/BasicEntityView.java
+++ b/src/main/java/com/hikari/hellofx/entity/view/BasicEntityView.java
@@ -9,6 +9,7 @@ import com.hikari.hellofx.entity.IConnectable;
 import com.hikari.hellofx.entity.ISuspendable;
 import com.hikari.hellofx.entity.model.ConnectionPoint;
 import com.hikari.hellofx.game.GameAction;
+import com.hikari.hellofx.game.control.BareAction;
 
 import javafx.application.Platform;
 import javafx.scene.layout.Pane;
@@ -27,7 +28,7 @@ public class BasicEntityView extends Pane implements IModelSubscriber {
 		setPrefSize(SIZE, SIZE);
 
 		shapePane = new ShapePane(SIZE, color);
-		shapePane.setOnMouseClicked(event -> bController.handleClick(event, GameAction.INFO));
+		shapePane.setOnMouseClicked(event -> bController.handleClick(new BareAction(GameAction.INFO, event)));
 		placeDefaultChildren();
 	}
 

--- a/src/main/java/com/hikari/hellofx/entity/view/ConnectableInfo.java
+++ b/src/main/java/com/hikari/hellofx/entity/view/ConnectableInfo.java
@@ -1,9 +1,14 @@
 package com.hikari.hellofx.entity.view;
 
+import java.util.List;
+
 import com.hikari.hellofx.base.BaseModel;
 import com.hikari.hellofx.base.IModelInfo;
 import com.hikari.hellofx.entity.BindingController;
+import com.hikari.hellofx.entity.IProducer;
 import com.hikari.hellofx.entity.ISuspendable;
+import com.hikari.hellofx.entity.Items;
+import com.hikari.hellofx.entity.RecipeManager;
 import com.hikari.hellofx.game.view.DespawnButton;
 import com.hikari.hellofx.game.view.SuspendButton;
 
@@ -29,12 +34,24 @@ public class ConnectableInfo extends VBox implements IModelInfo {
 
 	@Override
 	public void modelChanged(BaseModel model) {
+		//controller notifies before actually showing
+		if(text.getText().equals("")) {
+			initRecipeButtons((IProducer)model);
+		}
+		
 		String state = "My state is " + ((ISuspendable) model).isOn();
 		Platform.runLater(() -> {
 			text.setText(state + "\n I am " + model);
 			btn.setText("turn " + stringifyReversePowerState((ISuspendable) model));
 			log.debug(state);
 		});
+	}
+
+	private void initRecipeButtons(IProducer model) {
+		log.info(model.getClass().getName(), model);
+		for(Items i : RecipeManager.instance().getAllPossibleProducables(model.getClass())) {
+			//make a button
+		}
 	}
 
 	private String stringifyReversePowerState(ISuspendable model) {

--- a/src/main/java/com/hikari/hellofx/entity/view/ConnectionPointView.java
+++ b/src/main/java/com/hikari/hellofx/entity/view/ConnectionPointView.java
@@ -3,8 +3,8 @@ package com.hikari.hellofx.entity.view;
 import com.hikari.hellofx.base.BaseModel;
 import com.hikari.hellofx.base.IModelSubscriber;
 import com.hikari.hellofx.entity.BindingController;
-import com.hikari.hellofx.entity.model.ConnectionInPoint;
-import com.hikari.hellofx.entity.model.ConnectionPoint;
+import com.hikari.hellofx.entity.model.cpoint.ConnectionInPoint;
+import com.hikari.hellofx.entity.model.cpoint.ConnectionPoint;
 import com.hikari.hellofx.game.GameAction;
 import com.hikari.hellofx.game.control.FollowUpAction;
 

--- a/src/main/java/com/hikari/hellofx/entity/view/ConnectionPointView.java
+++ b/src/main/java/com/hikari/hellofx/entity/view/ConnectionPointView.java
@@ -6,6 +6,7 @@ import com.hikari.hellofx.entity.BindingController;
 import com.hikari.hellofx.entity.model.ConnectionInPoint;
 import com.hikari.hellofx.entity.model.ConnectionPoint;
 import com.hikari.hellofx.game.GameAction;
+import com.hikari.hellofx.game.control.FollowUpAction;
 
 import javafx.scene.paint.Color;
 import javafx.scene.shape.Circle;
@@ -15,33 +16,33 @@ public class ConnectionPointView extends Circle implements IModelSubscriber {
 	private static final int SIZE = 10;
 	
 	public ConnectionPointView(
-			ConnectionPoint model_, 
+			ConnectionPoint model, 
 			double parentSize, 
 			BindingController controller,
 			Double parentX,
 			Double parentY
 			) {
 		super(
-				parentSize/2 + parentSize*model_.getOffsetX(), 
-				parentSize/2 + parentSize*model_.getOffsetY(),
+				parentSize/2 + parentSize*model.getOffsetX(), 
+				parentSize/2 + parentSize*model.getOffsetY(),
 				SIZE
 				);
 		setFill(Color.AQUA);
-		model = model_;
+		this.model = model;
 		
 		model.subscribe(this);
 		model.setLastViewX(
-				parentX + parentSize/2 + parentSize*model_.getOffsetX()
+				parentX + parentSize/2 + parentSize*model.getOffsetX()
 				); // acturally its controller work
 		model.setLastViewY(
-				parentY + parentSize/2 + parentSize*model_.getOffsetY()
+				parentY + parentSize/2 + parentSize*model.getOffsetY()
 				); // anyway
 		//arr super constructor forces copypaste
-		GameAction action = (model_ instanceof ConnectionInPoint ? GameAction.CONNECT_IN : GameAction.CONNECT_OUT);
-		setOnMouseClicked(event -> controller.handleConnection(event, action, model));
+		GameAction action = (model instanceof ConnectionInPoint ? GameAction.CONNECT_IN : GameAction.CONNECT_OUT);
+		setOnMouseClicked(event -> controller.handleConnection(new FollowUpAction(action, event), model));
 	}
 	@Override
-	public void modelChanged(BaseModel model_) {
+	public void modelChanged(BaseModel model) {
 		// chill for now
 	}
 	public void unsubscribe() {

--- a/src/main/java/com/hikari/hellofx/entity/view/EntityShadowView.java
+++ b/src/main/java/com/hikari/hellofx/entity/view/EntityShadowView.java
@@ -5,6 +5,7 @@ import com.hikari.hellofx.base.IModelSubscriber;
 import com.hikari.hellofx.entity.model.EntityShadow;
 import com.hikari.hellofx.game.GameAction;
 import com.hikari.hellofx.game.GameController;
+import com.hikari.hellofx.game.control.FollowUpAction;
 
 import javafx.scene.CacheHint;
 import javafx.scene.paint.Color;
@@ -17,7 +18,7 @@ public class EntityShadowView extends Circle implements IModelSubscriber{
 		super(0,0,20);
 		setFill(Color.ALICEBLUE);
 		setVisible(false);
-		setOnMouseClicked((event) -> gController.act(event, GameAction.SPAWN));
+		setOnMouseClicked((event) -> gController.act(new FollowUpAction(GameAction.SPAWN, event)));
 	}
 	
 	public void enable() {

--- a/src/main/java/com/hikari/hellofx/entity/view/EntityShadowView.java
+++ b/src/main/java/com/hikari/hellofx/entity/view/EntityShadowView.java
@@ -18,7 +18,7 @@ public class EntityShadowView extends Circle implements IModelSubscriber{
 		super(0,0,20);
 		setFill(Color.ALICEBLUE);
 		setVisible(false);
-		setOnMouseClicked((event) -> gController.act(new FollowUpAction(GameAction.SPAWN, event)));
+		setOnMouseClicked(event -> gController.act(new FollowUpAction(GameAction.SPAWN, event)));
 	}
 	
 	public void enable() {

--- a/src/main/java/com/hikari/hellofx/entity/view/MergerView.java
+++ b/src/main/java/com/hikari/hellofx/entity/view/MergerView.java
@@ -1,0 +1,17 @@
+package com.hikari.hellofx.entity.view;
+
+import com.hikari.hellofx.entity.BindingController;
+
+import javafx.scene.paint.Color;
+
+public class MergerView extends BasicEntityView{
+	private static final Color MERGERCOLOR = Color.ALICEBLUE;
+
+	public MergerView(double x, double y, BindingController controller) {
+		super(x, y, controller, MERGERCOLOR);
+	}
+
+	public static Color getColor() {
+		return MERGERCOLOR;
+	}
+}

--- a/src/main/java/com/hikari/hellofx/entity/view/ShapePane.java
+++ b/src/main/java/com/hikari/hellofx/entity/view/ShapePane.java
@@ -47,6 +47,7 @@ class ShapePane extends StackPane {
 			getChildren().clear();
 			getChildren().add(field);
 			getChildren().add(pane);
+			pane.setMouseTransparent(true);
 			for (Slice i : slices) {
 				var y = size*(i.getHeight());
 				log.info(offset + y);

--- a/src/main/java/com/hikari/hellofx/entity/view/ShapePane.java
+++ b/src/main/java/com/hikari/hellofx/entity/view/ShapePane.java
@@ -7,9 +7,7 @@ import javafx.scene.layout.StackPane;
 import javafx.scene.paint.Color;
 import javafx.scene.shape.Rectangle;
 import javafx.scene.text.Text;
-import lombok.extern.log4j.Log4j2;
 
-@Log4j2
 class ShapePane extends StackPane {
 	private final Rectangle field;
 	private final Text label;
@@ -50,15 +48,12 @@ class ShapePane extends StackPane {
 			pane.setMouseTransparent(true);
 			for (Slice i : slices) {
 				var y = size*(i.getHeight());
-				log.info(offset + y);
 				var slice = new Rectangle(0, offset, size, y);
 				slice.setFill(i.getColor());
 				pane.getChildren().add(slice);
 				offset += y;
 			}
 			getChildren().add(label);
-		}else {
-			log.info("omitting slices render");
 		}
 	}
 

--- a/src/main/java/com/hikari/hellofx/entity/view/ShapePane.java
+++ b/src/main/java/com/hikari/hellofx/entity/view/ShapePane.java
@@ -1,32 +1,64 @@
 package com.hikari.hellofx.entity.view;
 
+import java.util.List;
+
+import javafx.scene.layout.Pane;
 import javafx.scene.layout.StackPane;
 import javafx.scene.paint.Color;
 import javafx.scene.shape.Rectangle;
 import javafx.scene.text.Text;
+import lombok.extern.log4j.Log4j2;
 
-class ShapePane extends StackPane{
+@Log4j2
+class ShapePane extends StackPane {
 	private final Rectangle field;
 	private final Text label;
-	
+	private double size;
+
 	public ShapePane(double size, Color color) {
 		this(size, "off", color);
 	}
-	
+
 	public ShapePane(double size, String text, Color color) {
-		field = new Rectangle(0,0,size,size);
+		this.size = size;
+		field = new Rectangle(0, 0, size, size);
 		label = new Text(text);
 		field.setFill(color);
 		field.setStroke(color.darker());
 		getChildren().add(field);
 		getChildren().add(label);
-		setPrefSize(size,size);
+		setPrefSize(size, size);
 	}
+
 	public Rectangle getField() {
 		return field;
 	}
+
 	public Text getLabel() {
 		return label;
 	}
-	
+
+	public void renderSlices(List<Slice> slices) {
+		//elsewhere generateSlices not defined
+		//TODO add caching and re-usage here, wildly inefficient yet fancy
+		if(!slices.isEmpty()) {
+			var offset = 0.0;
+			var pane  = new Pane();
+			getChildren().clear();
+			getChildren().add(field);
+			getChildren().add(pane);
+			for (Slice i : slices) {
+				var y = size*(i.getHeight());
+				log.info(offset + y);
+				var slice = new Rectangle(0, offset, size, y);
+				slice.setFill(i.getColor());
+				pane.getChildren().add(slice);
+				offset += y;
+			}
+			getChildren().add(label);
+		}else {
+			log.info("omitting slices render");
+		}
+	}
+
 }

--- a/src/main/java/com/hikari/hellofx/entity/view/Slice.java
+++ b/src/main/java/com/hikari/hellofx/entity/view/Slice.java
@@ -1,0 +1,18 @@
+package com.hikari.hellofx.entity.view;
+import javafx.scene.paint.Color;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+public class Slice {
+	@Getter
+	private final Double height;
+	@Getter
+	private final Color color;
+	@Override
+	public String toString() {
+		return height.toString();
+	}
+}

--- a/src/main/java/com/hikari/hellofx/entity/view/StorageView.java
+++ b/src/main/java/com/hikari/hellofx/entity/view/StorageView.java
@@ -9,9 +9,7 @@ import com.hikari.hellofx.entity.Item;
 import com.hikari.hellofx.entity.model.StorageModel;
 
 import javafx.scene.paint.Color;
-import lombok.extern.log4j.Log4j2;
 
-@Log4j2
 public class StorageView extends BasicEntityView {
 	private static final Color STORAGECOLOR = Color.AQUAMARINE;
 
@@ -27,10 +25,8 @@ public class StorageView extends BasicEntityView {
 	protected List<Slice> generateSlices(IConnectable model) {
 		var storage = ((StorageModel) model).getStorage();
 		var storageSize = ((StorageModel) model).getStorageSize();
-		List<Slice> list =  storage.keySet().stream()
+		return storage.keySet().stream()
 				.map(s -> new Slice(((double) storage.get(s)) / ((double) storageSize), Item.valueOf(s).getColor()))
 				.collect(Collectors.toList());
-		log.info(list);
-		return list;
 	}
 }

--- a/src/main/java/com/hikari/hellofx/entity/view/StorageView.java
+++ b/src/main/java/com/hikari/hellofx/entity/view/StorageView.java
@@ -1,9 +1,17 @@
 package com.hikari.hellofx.entity.view;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import com.hikari.hellofx.entity.BindingController;
+import com.hikari.hellofx.entity.IConnectable;
+import com.hikari.hellofx.entity.Item;
+import com.hikari.hellofx.entity.model.StorageModel;
 
 import javafx.scene.paint.Color;
+import lombok.extern.log4j.Log4j2;
 
+@Log4j2
 public class StorageView extends BasicEntityView {
 	private static final Color STORAGECOLOR = Color.AQUAMARINE;
 
@@ -13,5 +21,16 @@ public class StorageView extends BasicEntityView {
 
 	public static Color getColor() {
 		return STORAGECOLOR;
+	}
+
+	@Override
+	protected List<Slice> generateSlices(IConnectable model) {
+		var storage = ((StorageModel) model).getStorage();
+		var storageSize = ((StorageModel) model).getStorageSize();
+		List<Slice> list =  storage.keySet().stream()
+				.map(s -> new Slice(((double) storage.get(s)) / ((double) storageSize), Item.valueOf(s).getColor()))
+				.collect(Collectors.toList());
+		log.info(list);
+		return list;
 	}
 }

--- a/src/main/java/com/hikari/hellofx/entity/view/belt/BeltCart.java
+++ b/src/main/java/com/hikari/hellofx/entity/view/belt/BeltCart.java
@@ -2,7 +2,7 @@ package com.hikari.hellofx.entity.view.belt;
 
 import com.hikari.hellofx.base.BaseModel;
 import com.hikari.hellofx.base.IModelSubscriber;
-import com.hikari.hellofx.entity.model.belt.ModelItem;
+import com.hikari.hellofx.entity.model.belt.ItemCarriage;
 import com.hikari.hellofx.entity.model.belt.ModelItemStatus;
 
 import javafx.animation.TranslateTransition;
@@ -18,6 +18,7 @@ import lombok.extern.log4j.Log4j2;
 public class BeltCart extends Circle implements IModelSubscriber {
 	private static final int CART_RADIUS = 10;
 	private final TranslateTransition tr = new TranslateTransition();
+	private Color fill;
 	private String payloadName;
 
 	public BeltCart(Point2D position, Point2D translation, Duration travelTime) {
@@ -38,6 +39,7 @@ public class BeltCart extends Circle implements IModelSubscriber {
 
 	private void move() {
 		this.setVisible(true);
+		this.setFill(fill);
 		tr.play();
 		log.trace("moved " + payloadName);
 	}
@@ -51,10 +53,11 @@ public class BeltCart extends Circle implements IModelSubscriber {
 
 	@Override
 	public void modelChanged(BaseModel model) {
-		if (model instanceof ModelItem m) {
+		if (model instanceof ItemCarriage m) {
 			ModelItemStatus status = m.getStatus();
 			payloadName = m.getPayloadName();
 			if (status == ModelItemStatus.MOVED) {
+				fill = m.peekItem().getColor();
 				Platform.runLater(this::move);
 			} else if (status == ModelItemStatus.DISPATCHED) {
 				Platform.runLater(this::rewind);

--- a/src/main/java/com/hikari/hellofx/entity/view/belt/BeltCart.java
+++ b/src/main/java/com/hikari/hellofx/entity/view/belt/BeltCart.java
@@ -9,24 +9,34 @@ import javafx.animation.TranslateTransition;
 import javafx.application.Platform;
 import javafx.geometry.Point2D;
 import javafx.scene.CacheHint;
+import javafx.scene.layout.StackPane;
 import javafx.scene.paint.Color;
 import javafx.scene.shape.Circle;
+import javafx.scene.text.Text;
 import javafx.util.Duration;
 import lombok.extern.log4j.Log4j2;
 
 @Log4j2
-public class BeltCart extends Circle implements IModelSubscriber {
+public class BeltCart extends StackPane implements IModelSubscriber {
 	private static final int CART_RADIUS = 10;
+	private static final Color DEFAULT_COLOR = Color.WHITE;
 	private final TranslateTransition tr = new TranslateTransition();
+	private Circle cart = null;
+	private Text text = new Text();
+	private String tag = "";
 	private Color fill;
 	private String payloadName;
 
 	public BeltCart(Point2D position, Point2D translation, Duration travelTime) {
-		super(position.getX(), position.getY(), CART_RADIUS);
-		setFill(Color.VIOLET);
+		cart = new Circle(CART_RADIUS);
+		setLayoutX(position.getX() - CART_RADIUS);
+		setLayoutY(position.getY() - CART_RADIUS);
+		cart.setFill(DEFAULT_COLOR);
 		setCache(true);
 		setCacheHint(CacheHint.SPEED);
 		initTranslation(translation, travelTime);
+		this.getChildren().add(cart);
+		this.getChildren().add(text);
 		this.setVisible(false);
 	}
 
@@ -39,7 +49,8 @@ public class BeltCart extends Circle implements IModelSubscriber {
 
 	private void move() {
 		this.setVisible(true);
-		this.setFill(fill);
+		cart.setFill(fill);
+		text.setText(tag);
 		tr.play();
 		log.trace("moved " + payloadName);
 	}
@@ -58,6 +69,7 @@ public class BeltCart extends Circle implements IModelSubscriber {
 			payloadName = m.getPayloadName();
 			if (status == ModelItemStatus.MOVED) {
 				fill = m.peekItem().getColor();
+				tag = m.peekItem().getTag();
 				Platform.runLater(this::move);
 			} else if (status == ModelItemStatus.DISPATCHED) {
 				Platform.runLater(this::rewind);

--- a/src/main/java/com/hikari/hellofx/entity/view/belt/BeltView.java
+++ b/src/main/java/com/hikari/hellofx/entity/view/belt/BeltView.java
@@ -7,7 +7,7 @@ import com.hikari.hellofx.base.BaseModel;
 import com.hikari.hellofx.entity.model.ConnectionInPoint;
 import com.hikari.hellofx.entity.model.ConnectionOutPoint;
 import com.hikari.hellofx.entity.model.belt.Belt;
-import com.hikari.hellofx.entity.model.belt.ModelItem;
+import com.hikari.hellofx.entity.model.belt.ItemCarriage;
 import com.hikari.hellofx.entity.view.BasicConnectionView;
 
 import javafx.geometry.Point2D;
@@ -33,11 +33,12 @@ public class BeltView extends BasicConnectionView{
 		
 		@Override
 		public void modelChanged(BaseModel model) {
+			//initial subscription
 			if(model instanceof Belt belt) {
 				double n = belt.getSlotsCount();
 				var translation = new Point2D((end.getX() - start.getX())/n, (end.getY() - start.getY())/n);
-				List<ModelItem> items = belt.getItemModels();
-				for(ModelItem m : items) {
+				List<ItemCarriage> items = belt.getItemModels();
+				for(ItemCarriage m : items) {
 					var cart = new BeltCart(start, translation, Duration.millis((double)belt.getCellTravelTime() - 10.0));
 					m.subscribe(cart);
 					carts.add(cart);

--- a/src/main/java/com/hikari/hellofx/entity/view/belt/BeltView.java
+++ b/src/main/java/com/hikari/hellofx/entity/view/belt/BeltView.java
@@ -4,10 +4,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.hikari.hellofx.base.BaseModel;
-import com.hikari.hellofx.entity.model.ConnectionInPoint;
-import com.hikari.hellofx.entity.model.ConnectionOutPoint;
 import com.hikari.hellofx.entity.model.belt.Belt;
 import com.hikari.hellofx.entity.model.belt.ItemCarriage;
+import com.hikari.hellofx.entity.model.cpoint.ConnectionInPoint;
+import com.hikari.hellofx.entity.model.cpoint.ConnectionOutPoint;
 import com.hikari.hellofx.entity.view.BasicConnectionView;
 
 import javafx.geometry.Point2D;

--- a/src/main/java/com/hikari/hellofx/entity/view/conveyor/Cart.java
+++ b/src/main/java/com/hikari/hellofx/entity/view/conveyor/Cart.java
@@ -1,19 +1,32 @@
 package com.hikari.hellofx.entity.view.conveyor;
 
+import com.hikari.hellofx.entity.Item;
+
 import javafx.application.Platform;
 import javafx.geometry.Point2D;
 import javafx.scene.layout.Pane;
-import javafx.scene.paint.Color;
+import javafx.scene.layout.StackPane;
 import javafx.scene.shape.Circle;
+import javafx.scene.text.Text;
 
-public class Cart extends Circle {
+public class Cart extends StackPane {
 	Pane view;
+	private static final int CART_RADIUS = 10;
+	
 
-	public Cart(Point2D p, Pane view_) {
-		super(p.getX(), p.getY(), 10);
-		view = view_;
-		setFill(Color.VIOLET);
-		Platform.runLater(() -> view.getChildren().add(this));
+	public Cart(Point2D p, Pane view, Item item) {
+		setLayoutX(p.getX() - CART_RADIUS);
+		setLayoutY(p.getY() - CART_RADIUS);
+		var circle = new Circle(CART_RADIUS);
+		circle.setFill(item.getColor());
+		var text = new Text(item.getTag());
+		this.view = view;
+
+		Platform.runLater(() -> {
+			view.getChildren().add(this);
+			this.getChildren().add(circle);
+			this.getChildren().add(text);
+		});
 	}
 
 	public void dismiss() {

--- a/src/main/java/com/hikari/hellofx/entity/view/conveyor/ConveyorView.java
+++ b/src/main/java/com/hikari/hellofx/entity/view/conveyor/ConveyorView.java
@@ -4,9 +4,9 @@ import java.util.ArrayDeque;
 
 import com.hikari.hellofx.base.BaseModel;
 import com.hikari.hellofx.entity.Item;
-import com.hikari.hellofx.entity.model.ConnectionInPoint;
-import com.hikari.hellofx.entity.model.ConnectionOutPoint;
 import com.hikari.hellofx.entity.model.conveyor.Conveyor;
+import com.hikari.hellofx.entity.model.cpoint.ConnectionInPoint;
+import com.hikari.hellofx.entity.model.cpoint.ConnectionOutPoint;
 import com.hikari.hellofx.entity.view.BasicConnectionView;
 
 import javafx.geometry.Point2D;

--- a/src/main/java/com/hikari/hellofx/entity/view/conveyor/ConveyorView.java
+++ b/src/main/java/com/hikari/hellofx/entity/view/conveyor/ConveyorView.java
@@ -14,8 +14,8 @@ import javafx.scene.shape.Line;
 import javafx.util.Duration;
 
 public class ConveyorView extends BasicConnectionView {
-	// todo rework to single pool of refire-able transitions for caching
-	private final ArrayDeque<EntityTransition> transitions = new ArrayDeque<EntityTransition>(10);
+	//Kept for legacy, belt impl is far better
+	private final ArrayDeque<EntityTransition> transitions = new ArrayDeque<>(10);
 	Line road;
 	Duration duration = Duration.millis(1000); // default
 	private final Point2D start;

--- a/src/main/java/com/hikari/hellofx/entity/view/conveyor/ConveyorView.java
+++ b/src/main/java/com/hikari/hellofx/entity/view/conveyor/ConveyorView.java
@@ -3,6 +3,7 @@ package com.hikari.hellofx.entity.view.conveyor;
 import java.util.ArrayDeque;
 
 import com.hikari.hellofx.base.BaseModel;
+import com.hikari.hellofx.entity.Item;
 import com.hikari.hellofx.entity.model.ConnectionInPoint;
 import com.hikari.hellofx.entity.model.ConnectionOutPoint;
 import com.hikari.hellofx.entity.model.conveyor.Conveyor;
@@ -33,9 +34,10 @@ public class ConveyorView extends BasicConnectionView {
 	public void modelChanged(BaseModel model) {
 		duration = (Duration.millis(((Conveyor) model).getTravelTime()));
 		var e = ((Conveyor) model).getLastConnectionEvent();
+		Item item = (Item)((Conveyor) model).getPayload();
 		switch (e) {
 		case DEPARTED:
-			var entityTransition = new EntityTransition(duration, start, end, this);
+			var entityTransition = new EntityTransition(duration, start, end, this, item);
 			transitions.add(entityTransition);
 			break;
 		case ARRIVED:

--- a/src/main/java/com/hikari/hellofx/entity/view/conveyor/EntityTransition.java
+++ b/src/main/java/com/hikari/hellofx/entity/view/conveyor/EntityTransition.java
@@ -1,5 +1,7 @@
 package com.hikari.hellofx.entity.view.conveyor;
 
+import com.hikari.hellofx.entity.Item;
+
 import javafx.animation.TranslateTransition;
 import javafx.application.Platform;
 import javafx.geometry.Point2D;
@@ -9,12 +11,12 @@ import javafx.util.Duration;
 public class EntityTransition {
 	private final Cart cart;
 
-	public EntityTransition(Duration duration, Point2D start, Point2D end, Pane parent) {
-		cart = new Cart(start, parent);
-		TranslateTransition tr = new TranslateTransition(duration, cart);
+	public EntityTransition(Duration duration, Point2D start, Point2D end, Pane parent, Item item) {
+		cart = new Cart(start, parent, item);
+		var tr = new TranslateTransition(duration, cart);
 		tr.setByX(end.getX() - start.getX());
 		tr.setByY(end.getY() - start.getY());
-		Platform.runLater(() -> tr.play());
+		Platform.runLater(tr::play);
 	}
 
 	public void dismiss() {

--- a/src/main/java/com/hikari/hellofx/entity/view/info/ConnectableInfo.java
+++ b/src/main/java/com/hikari/hellofx/entity/view/info/ConnectableInfo.java
@@ -30,24 +30,32 @@ public class ConnectableInfo extends VBox implements IModelInfo {
 
 	@Override
 	public void modelChanged(BaseModel model) {
-		//controller notifies before actually showing
-		if(text.getText().equals("") && model instanceof IProducer producer) {
+		// controller notifies before actually showing
+
+		if (model instanceof IProducer producer) {
 			initRecipeButtons(producer);
 		}
-		
-		String state = "My state is " + ((ISuspendable) model).isOn();
 		Platform.runLater(() -> {
-			text.setText(state + "\n I am " + model);
+			var state = stringifyState(model);
+			text.setText(state);
 			btn.setText("turn " + stringifyReversePowerState((ISuspendable) model));
 			log.debug(state);
 		});
 	}
 
+	public String stringifyState(BaseModel model) {
+		String state = "My state is " + ((ISuspendable) model).isOn();
+		if (model instanceof IProducer producer) {
+			state = state + "\n producing " + producer.getCurrentRecipe().produce();
+		}
+		return state;
+	}
+
 	private void initRecipeButtons(IProducer model) {
-		//TODO: now it is like Minecraft recipes - you need to remember ingredients
-		//at least placement doesnt matter due to usage of Set
+		// TODO: now it is like Minecraft recipes - you need to remember ingredients
+		// at least placement doesnt matter due to usage of Set
 		log.info(model.getClass().getName(), model);
-		for(Item i : RecipeManager.instance().getAllPossibleProducables(model.getClass())) {
+		for (Item i : RecipeManager.instance().getAllPossibleProducables(model.getClass())) {
 			add(new RecipeButton(controller, i.toString(), i));
 		}
 	}

--- a/src/main/java/com/hikari/hellofx/entity/view/info/ConnectableInfo.java
+++ b/src/main/java/com/hikari/hellofx/entity/view/info/ConnectableInfo.java
@@ -1,6 +1,4 @@
-package com.hikari.hellofx.entity.view;
-
-import java.util.List;
+package com.hikari.hellofx.entity.view.info;
 
 import com.hikari.hellofx.base.BaseModel;
 import com.hikari.hellofx.base.IModelInfo;
@@ -9,8 +7,6 @@ import com.hikari.hellofx.entity.IProducer;
 import com.hikari.hellofx.entity.ISuspendable;
 import com.hikari.hellofx.entity.Items;
 import com.hikari.hellofx.entity.RecipeManager;
-import com.hikari.hellofx.game.view.DespawnButton;
-import com.hikari.hellofx.game.view.SuspendButton;
 
 import javafx.scene.layout.VBox;
 import javafx.scene.text.Text;
@@ -50,7 +46,7 @@ public class ConnectableInfo extends VBox implements IModelInfo {
 	private void initRecipeButtons(IProducer model) {
 		log.info(model.getClass().getName(), model);
 		for(Items i : RecipeManager.instance().getAllPossibleProducables(model.getClass())) {
-			//make a button
+			add(new RecipeButton(controller, i.toString()));
 		}
 	}
 

--- a/src/main/java/com/hikari/hellofx/entity/view/info/ConnectableInfo.java
+++ b/src/main/java/com/hikari/hellofx/entity/view/info/ConnectableInfo.java
@@ -44,6 +44,8 @@ public class ConnectableInfo extends VBox implements IModelInfo {
 	}
 
 	private void initRecipeButtons(IProducer model) {
+		//TODO: now it is like Minecraft recipes - you need to remember ingredients
+		//at least placement doesnt matter due to usage of Set
 		log.info(model.getClass().getName(), model);
 		for(Item i : RecipeManager.instance().getAllPossibleProducables(model.getClass())) {
 			add(new RecipeButton(controller, i.toString(), i));

--- a/src/main/java/com/hikari/hellofx/entity/view/info/ConnectableInfo.java
+++ b/src/main/java/com/hikari/hellofx/entity/view/info/ConnectableInfo.java
@@ -5,7 +5,7 @@ import com.hikari.hellofx.base.IModelInfo;
 import com.hikari.hellofx.entity.BindingController;
 import com.hikari.hellofx.entity.IProducer;
 import com.hikari.hellofx.entity.ISuspendable;
-import com.hikari.hellofx.entity.Items;
+import com.hikari.hellofx.entity.Item;
 import com.hikari.hellofx.entity.RecipeManager;
 
 import javafx.scene.layout.VBox;
@@ -45,7 +45,7 @@ public class ConnectableInfo extends VBox implements IModelInfo {
 
 	private void initRecipeButtons(IProducer model) {
 		log.info(model.getClass().getName(), model);
-		for(Items i : RecipeManager.instance().getAllPossibleProducables(model.getClass())) {
+		for(Item i : RecipeManager.instance().getAllPossibleProducables(model.getClass())) {
 			add(new RecipeButton(controller, i.toString(), i));
 		}
 	}

--- a/src/main/java/com/hikari/hellofx/entity/view/info/ConnectableInfo.java
+++ b/src/main/java/com/hikari/hellofx/entity/view/info/ConnectableInfo.java
@@ -31,8 +31,8 @@ public class ConnectableInfo extends VBox implements IModelInfo {
 	@Override
 	public void modelChanged(BaseModel model) {
 		//controller notifies before actually showing
-		if(text.getText().equals("")) {
-			initRecipeButtons((IProducer)model);
+		if(text.getText().equals("") && model instanceof IProducer producer) {
+			initRecipeButtons(producer);
 		}
 		
 		String state = "My state is " + ((ISuspendable) model).isOn();
@@ -46,7 +46,7 @@ public class ConnectableInfo extends VBox implements IModelInfo {
 	private void initRecipeButtons(IProducer model) {
 		log.info(model.getClass().getName(), model);
 		for(Items i : RecipeManager.instance().getAllPossibleProducables(model.getClass())) {
-			add(new RecipeButton(controller, i.toString()));
+			add(new RecipeButton(controller, i.toString(), i));
 		}
 	}
 

--- a/src/main/java/com/hikari/hellofx/entity/view/info/DespawnButton.java
+++ b/src/main/java/com/hikari/hellofx/entity/view/info/DespawnButton.java
@@ -9,6 +9,6 @@ import javafx.scene.control.Button;
 public class DespawnButton extends Button{
 	public DespawnButton(BindingController bController, String label) {
 		super(label);
-		setOnMouseClicked((event)->bController.handleClick(new BareAction(GameAction.DESPAWN, event)));
+		setOnMouseClicked(event -> bController.handleClick(new BareAction(GameAction.DESPAWN, event)));
 	}
 }

--- a/src/main/java/com/hikari/hellofx/entity/view/info/DespawnButton.java
+++ b/src/main/java/com/hikari/hellofx/entity/view/info/DespawnButton.java
@@ -1,4 +1,4 @@
-package com.hikari.hellofx.game.view;
+package com.hikari.hellofx.entity.view.info;
 
 import com.hikari.hellofx.entity.BindingController;
 import com.hikari.hellofx.game.GameAction;

--- a/src/main/java/com/hikari/hellofx/entity/view/info/DespawnButton.java
+++ b/src/main/java/com/hikari/hellofx/entity/view/info/DespawnButton.java
@@ -2,12 +2,13 @@ package com.hikari.hellofx.entity.view.info;
 
 import com.hikari.hellofx.entity.BindingController;
 import com.hikari.hellofx.game.GameAction;
+import com.hikari.hellofx.game.control.BareAction;
 
 import javafx.scene.control.Button;
 
 public class DespawnButton extends Button{
 	public DespawnButton(BindingController bController, String label) {
 		super(label);
-		setOnMouseClicked((event)->bController.handleClick(event, GameAction.DESPAWN));
+		setOnMouseClicked((event)->bController.handleClick(new BareAction(GameAction.DESPAWN, event)));
 	}
 }

--- a/src/main/java/com/hikari/hellofx/entity/view/info/RecipeButton.java
+++ b/src/main/java/com/hikari/hellofx/entity/view/info/RecipeButton.java
@@ -1,0 +1,13 @@
+package com.hikari.hellofx.entity.view.info;
+
+import com.hikari.hellofx.entity.BindingController;
+import com.hikari.hellofx.game.GameAction;
+
+import javafx.scene.control.Button;
+
+public class RecipeButton extends Button{
+	public RecipeButton(BindingController bController, String label) {
+		super(label);
+		setOnMouseClicked((event)->bController.handleClick(event, GameAction.RECIPE));
+	}
+}

--- a/src/main/java/com/hikari/hellofx/entity/view/info/RecipeButton.java
+++ b/src/main/java/com/hikari/hellofx/entity/view/info/RecipeButton.java
@@ -1,14 +1,14 @@
 package com.hikari.hellofx.entity.view.info;
 
 import com.hikari.hellofx.entity.BindingController;
-import com.hikari.hellofx.entity.Items;
+import com.hikari.hellofx.entity.Item;
 import com.hikari.hellofx.game.GameAction;
 import com.hikari.hellofx.game.control.RecipeAction;
 
 import javafx.scene.control.Button;
 
 public class RecipeButton extends Button {
-	public RecipeButton(BindingController bController, String label, Items item) {
+	public RecipeButton(BindingController bController, String label, Item item) {
 		super(label);
 		setOnMouseClicked(event -> bController.handleClick(new RecipeAction(GameAction.RECIPE, event, item)));
 	}

--- a/src/main/java/com/hikari/hellofx/entity/view/info/RecipeButton.java
+++ b/src/main/java/com/hikari/hellofx/entity/view/info/RecipeButton.java
@@ -1,13 +1,15 @@
 package com.hikari.hellofx.entity.view.info;
 
 import com.hikari.hellofx.entity.BindingController;
+import com.hikari.hellofx.entity.Items;
 import com.hikari.hellofx.game.GameAction;
+import com.hikari.hellofx.game.control.RecipeAction;
 
 import javafx.scene.control.Button;
 
-public class RecipeButton extends Button{
-	public RecipeButton(BindingController bController, String label) {
+public class RecipeButton extends Button {
+	public RecipeButton(BindingController bController, String label, Items item) {
 		super(label);
-		setOnMouseClicked((event)->bController.handleClick(event, GameAction.RECIPE));
+		setOnMouseClicked(event -> bController.handleClick(new RecipeAction(GameAction.RECIPE, event, item)));
 	}
 }

--- a/src/main/java/com/hikari/hellofx/entity/view/info/SuspendButton.java
+++ b/src/main/java/com/hikari/hellofx/entity/view/info/SuspendButton.java
@@ -1,4 +1,4 @@
-package com.hikari.hellofx.game.view;
+package com.hikari.hellofx.entity.view.info;
 
 import com.hikari.hellofx.entity.BindingController;
 import com.hikari.hellofx.game.GameAction;

--- a/src/main/java/com/hikari/hellofx/entity/view/info/SuspendButton.java
+++ b/src/main/java/com/hikari/hellofx/entity/view/info/SuspendButton.java
@@ -2,12 +2,13 @@ package com.hikari.hellofx.entity.view.info;
 
 import com.hikari.hellofx.entity.BindingController;
 import com.hikari.hellofx.game.GameAction;
+import com.hikari.hellofx.game.control.BareAction;
 
 import javafx.scene.control.Button;
 
-public class SuspendButton extends Button{
+public class SuspendButton extends Button {
 	public SuspendButton(BindingController bController, String label) {
 		super(label);
-		setOnMouseClicked((event)->bController.handleClick(event, GameAction.SUSPEND));
+		setOnMouseClicked(event -> bController.handleClick(new BareAction(GameAction.SUSPEND, event)));
 	}
 }

--- a/src/main/java/com/hikari/hellofx/game/Game.java
+++ b/src/main/java/com/hikari/hellofx/game/Game.java
@@ -38,8 +38,8 @@ public class Game extends BaseModel {
 		//look at this monstrocity x)
 		List<BasicConnectionView> res = new ArrayList<>();
 		List<IConnection> modelCollections = Stream.concat(
-				model.getInPoints().stream().filter(ConnectionPoint::isFree).map(ConnectionPoint::getConnection), 
-				model.getOutPoints().stream().filter(ConnectionPoint::isFree).map(ConnectionPoint::getConnection))
+				model.getInPoints().stream().filter(c -> !c.isFree()).map(ConnectionPoint::getConnection), 
+				model.getOutPoints().stream().filter(c -> !c.isFree()).map(ConnectionPoint::getConnection))
 				.collect(Collectors.toList());
 		for(IConnection i : modelCollections) {
 			i.markDetached();
@@ -52,8 +52,7 @@ public class Game extends BaseModel {
 		// TODO rework to proper interrupt and stop-the-world
 		entityServices.get(model).safeStop();
 		entityServices.remove(model);
-		var view = entityViews.get(model);
-		entityViews.remove(model);
+		var view = entityViews.remove(model);
 		entityModels.remove(model);
 		return view;
 	}

--- a/src/main/java/com/hikari/hellofx/game/Game.java
+++ b/src/main/java/com/hikari/hellofx/game/Game.java
@@ -1,29 +1,45 @@
 package com.hikari.hellofx.game;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
 
 import com.hikari.hellofx.base.BaseModel;
+import com.hikari.hellofx.base.BaseService;
 import com.hikari.hellofx.entity.IConnectable;
 import com.hikari.hellofx.entity.IConnection;
+import com.hikari.hellofx.entity.view.BasicEntityView;
 
 
-	/* TODO: decompose GameScene's model logic to here
-	 * need time to comprehend
-	 */
 public class Game extends BaseModel{
-	private final ArrayList<IConnectable> entityModels = new ArrayList<IConnectable>();
-	private final ArrayList<IConnection> connections = new ArrayList<IConnection>();
+	private final List<IConnectable> entityModels = new ArrayList<>();
+	private final Map<IConnectable, BasicEntityView> entityViews = new HashMap<>();
+	private final Map<IConnectable, BaseService> entityServices = new HashMap<>();
+	private final List<IConnection> connections = new ArrayList<>();
 	GameFieldModel gameFieldModel = new GameFieldModel();
 	
 	public GameFieldModel getField() {
 		return gameFieldModel;
 	}
 
-	public void addEntity(IConnectable model) {
+	public void addEntity(IConnectable model, BasicEntityView view, BaseService service) {
 		entityModels.add(model);
+		entityViews.put(model, view);
+		entityServices.put(model, service);
 	}
 	
+	public BasicEntityView removeEntity(IConnectable model) {
+		//TODO rework to proper interrupt and stop-the-world
+		entityServices.get(model).interrupt();
+		entityServices.remove(model);
+		var view = entityViews.get(model);
+		entityViews.remove(model);
+		entityModels.remove(model);
+		return view;
+	}
+		
 	public void addConnection(IConnection connection) {
 		connections.add(connection);
 	}

--- a/src/main/java/com/hikari/hellofx/game/Game.java
+++ b/src/main/java/com/hikari/hellofx/game/Game.java
@@ -65,7 +65,16 @@ public class Game extends BaseModel {
 		connectionServices.put(connection, service);
 	}
 
-	public void forEachEntity(Consumer<IConnectable> f) {
-		entityModels.stream().forEach(f);
+	public void removeAll() {
+		forEachEntity(this::removeConnections);
+		for(IConnectable i : entityModels) {
+			entityServices.get(i).safeStop();
+			entityServices.remove(i);
+		}
 	}
+	
+	public void forEachEntity(Consumer<IConnectable> f) {
+			entityModels.stream().forEach(f);
+	}
+
 }

--- a/src/main/java/com/hikari/hellofx/game/Game.java
+++ b/src/main/java/com/hikari/hellofx/game/Game.java
@@ -12,6 +12,8 @@ import com.hikari.hellofx.base.BaseModel;
 import com.hikari.hellofx.base.BaseService;
 import com.hikari.hellofx.entity.IConnectable;
 import com.hikari.hellofx.entity.IConnection;
+import com.hikari.hellofx.entity.model.cpoint.ConnectionInPoint;
+import com.hikari.hellofx.entity.model.cpoint.ConnectionOutPoint;
 import com.hikari.hellofx.entity.model.cpoint.ConnectionPoint;
 import com.hikari.hellofx.entity.view.BasicConnectionView;
 import com.hikari.hellofx.entity.view.BasicEntityView;
@@ -39,8 +41,8 @@ public class Game extends BaseModel {
 		//look at this monstrocity x)
 		List<BasicConnectionView> res = new ArrayList<>();
 		List<IConnection> modelCollections = Stream.concat(
-				model.getInPoints().stream().filter(c -> !c.isFree()).map(ConnectionPoint::getConnection), 
-				model.getOutPoints().stream().filter(c -> !c.isFree()).map(ConnectionPoint::getConnection))
+				model.filterNonFreePoints(ConnectionInPoint.class).stream().map(ConnectionPoint::getConnection), 
+				model.filterNonFreePoints(ConnectionOutPoint.class).stream().map(ConnectionPoint::getConnection))
 				.collect(Collectors.toList());
 		for(IConnection i : modelCollections) {
 			i.markDetached();

--- a/src/main/java/com/hikari/hellofx/game/Game.java
+++ b/src/main/java/com/hikari/hellofx/game/Game.java
@@ -22,6 +22,7 @@ public class Game extends BaseModel {
 	private final Map<IConnectable, BaseService> entityServices = new HashMap<>();
 	private final List<IConnection> connections = new ArrayList<>();
 	private final Map<IConnection, BasicConnectionView> connectionViews = new HashMap<>();
+	private final Map<IConnection, BaseService> connectionServices = new HashMap<>();
 	GameFieldModel gameFieldModel = new GameFieldModel();
 
 	public GameFieldModel getField() {
@@ -34,7 +35,7 @@ public class Game extends BaseModel {
 		entityServices.put(model, service);
 	}
 
-	public List<BasicConnectionView> removeConnectionViews(IConnectable model) {
+	public List<BasicConnectionView> removeConnections(IConnectable model) {
 		//look at this monstrocity x)
 		List<BasicConnectionView> res = new ArrayList<>();
 		List<IConnection> modelCollections = Stream.concat(
@@ -43,6 +44,8 @@ public class Game extends BaseModel {
 				.collect(Collectors.toList());
 		for(IConnection i : modelCollections) {
 			i.markDetached();
+			//TODO leaving trail of stopped connection refs
+			connectionServices.get(i).safeStop();
 			res.add(connectionViews.remove(i));
 		}
 		return res;
@@ -56,9 +59,10 @@ public class Game extends BaseModel {
 		return view;
 	}
 
-	public void addConnection(IConnection connection, BasicConnectionView view) {
+	public void addConnection(IConnection connection, BasicConnectionView view, BaseService service) {
 		connections.add(connection);
 		connectionViews.put(connection, view);
+		connectionServices.put(connection, service);
 	}
 
 	public void forEachEntity(Consumer<IConnectable> f) {

--- a/src/main/java/com/hikari/hellofx/game/Game.java
+++ b/src/main/java/com/hikari/hellofx/game/Game.java
@@ -12,7 +12,7 @@ import com.hikari.hellofx.base.BaseModel;
 import com.hikari.hellofx.base.BaseService;
 import com.hikari.hellofx.entity.IConnectable;
 import com.hikari.hellofx.entity.IConnection;
-import com.hikari.hellofx.entity.model.ConnectionPoint;
+import com.hikari.hellofx.entity.model.cpoint.ConnectionPoint;
 import com.hikari.hellofx.entity.view.BasicConnectionView;
 import com.hikari.hellofx.entity.view.BasicEntityView;
 
@@ -49,7 +49,6 @@ public class Game extends BaseModel {
 	}
 
 	public BasicEntityView removeEntity(IConnectable model) {
-		// TODO rework to proper interrupt and stop-the-world
 		entityServices.get(model).safeStop();
 		entityServices.remove(model);
 		var view = entityViews.remove(model);

--- a/src/main/java/com/hikari/hellofx/game/Game.java
+++ b/src/main/java/com/hikari/hellofx/game/Game.java
@@ -32,7 +32,7 @@ public class Game extends BaseModel{
 	
 	public BasicEntityView removeEntity(IConnectable model) {
 		//TODO rework to proper interrupt and stop-the-world
-		entityServices.get(model).interrupt();
+		entityServices.get(model).safeStop();
 		entityServices.remove(model);
 		var view = entityViews.get(model);
 		entityViews.remove(model);

--- a/src/main/java/com/hikari/hellofx/game/Game.java
+++ b/src/main/java/com/hikari/hellofx/game/Game.java
@@ -5,21 +5,25 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import com.hikari.hellofx.base.BaseModel;
 import com.hikari.hellofx.base.BaseService;
 import com.hikari.hellofx.entity.IConnectable;
 import com.hikari.hellofx.entity.IConnection;
+import com.hikari.hellofx.entity.model.ConnectionPoint;
+import com.hikari.hellofx.entity.view.BasicConnectionView;
 import com.hikari.hellofx.entity.view.BasicEntityView;
 
-
-public class Game extends BaseModel{
+public class Game extends BaseModel {
 	private final List<IConnectable> entityModels = new ArrayList<>();
 	private final Map<IConnectable, BasicEntityView> entityViews = new HashMap<>();
 	private final Map<IConnectable, BaseService> entityServices = new HashMap<>();
 	private final List<IConnection> connections = new ArrayList<>();
+	private final Map<IConnection, BasicConnectionView> connectionViews = new HashMap<>();
 	GameFieldModel gameFieldModel = new GameFieldModel();
-	
+
 	public GameFieldModel getField() {
 		return gameFieldModel;
 	}
@@ -29,9 +33,23 @@ public class Game extends BaseModel{
 		entityViews.put(model, view);
 		entityServices.put(model, service);
 	}
-	
+
+	public List<BasicConnectionView> removeConnectionViews(IConnectable model) {
+		//look at this monstrocity x)
+		List<BasicConnectionView> res = new ArrayList<>();
+		List<IConnection> modelCollections = Stream.concat(
+				model.getInPoints().stream().filter(ConnectionPoint::isFree).map(ConnectionPoint::getConnection), 
+				model.getOutPoints().stream().filter(ConnectionPoint::isFree).map(ConnectionPoint::getConnection))
+				.collect(Collectors.toList());
+		for(IConnection i : modelCollections) {
+			i.markDetached();
+			res.add(connectionViews.remove(i));
+		}
+		return res;
+	}
+
 	public BasicEntityView removeEntity(IConnectable model) {
-		//TODO rework to proper interrupt and stop-the-world
+		// TODO rework to proper interrupt and stop-the-world
 		entityServices.get(model).safeStop();
 		entityServices.remove(model);
 		var view = entityViews.get(model);
@@ -39,11 +57,12 @@ public class Game extends BaseModel{
 		entityModels.remove(model);
 		return view;
 	}
-		
-	public void addConnection(IConnection connection) {
+
+	public void addConnection(IConnection connection, BasicConnectionView view) {
 		connections.add(connection);
+		connectionViews.put(connection, view);
 	}
-	
+
 	public void forEachEntity(Consumer<IConnectable> f) {
 		entityModels.stream().forEach(f);
 	}

--- a/src/main/java/com/hikari/hellofx/game/GameAction.java
+++ b/src/main/java/com/hikari/hellofx/game/GameAction.java
@@ -10,5 +10,6 @@ public enum GameAction {
 	CONNECT_OUT,
 	DESPAWN,
 	CANCEL,
+	RECIPE,
 	NOP,
 }

--- a/src/main/java/com/hikari/hellofx/game/GameController.java
+++ b/src/main/java/com/hikari/hellofx/game/GameController.java
@@ -6,13 +6,17 @@ import com.hikari.hellofx.base.BaseModel;
 import com.hikari.hellofx.base.IModelInfo;
 import com.hikari.hellofx.entity.BindingController;
 import com.hikari.hellofx.entity.IConnectable;
+import com.hikari.hellofx.entity.IProducer;
 import com.hikari.hellofx.entity.model.BasicEntityModel;
 import com.hikari.hellofx.entity.model.ConnectableState;
 import com.hikari.hellofx.entity.model.ConnectionInPoint;
 import com.hikari.hellofx.entity.model.ConnectionOutPoint;
 import com.hikari.hellofx.entity.model.EntityShadow;
 import com.hikari.hellofx.entity.view.info.ConnectableInfo;
-import com.hikari.hellofx.game.classpack.ClassPack;
+import com.hikari.hellofx.game.control.ControlTransferObject;
+import com.hikari.hellofx.game.control.FollowUpAction;
+import com.hikari.hellofx.game.control.PackAction;
+import com.hikari.hellofx.game.control.RecipeAction;
 import com.hikari.hellofx.game.view.GameField;
 import com.hikari.hellofx.game.view.GameView;
 
@@ -22,22 +26,23 @@ import lombok.extern.log4j.Log4j2;
 
 @Log4j2
 public class GameController{
+	private static final String ILLEGAL_BUTTON_ARGUMENT = "button reported wrong args:";
+	
 	enum State {
 		IDLE, SPAWNING, CONNECTING_FIRST, CONNECTING_SECOND
 	}
 
 	enum Action {
-		Notice, Act, Nop
+		NOTICE, ACT, NOP
 	}
 
 	private State state = State.IDLE;
-	private Action lastAction = Action.Nop;
-	private GameAction action = GameAction.NOP;
+	private Action lastAction = Action.NOP;
 	private final Game game = new Game();
 	private final GameView view;
 	private final EntityShadow shadow = new EntityShadow();
 	private final ArrayDeque<BaseModel> noticed = new ArrayDeque<>();
-	private ClassPack classPack = null;
+	private ControlTransferObject cto = null;
 
 	public GameController(GameView view_) {
 		view = view_;
@@ -56,42 +61,45 @@ public class GameController{
 		game.forEachEntity(w -> w.setConnectableState(ConnectableState.OUT_POINTS));
 	}
 
-	public void act(MouseEvent event, GameAction action_, ClassPack pack) {
-		lastAction = Action.Act;
-		action = action_;
-		classPack = pack;
-		assignHandler(event);
+	public void act(ControlTransferObject cto) {
+		lastAction = Action.ACT;
+		updateCTO(cto);
+		assignHandler();
 	}
 
-	public void act(MouseEvent event, GameAction action_) {
-		act(event, action_, classPack);
-	}
-
-	public void notice(BaseModel model, MouseEvent event, GameAction action_) {
-		lastAction = Action.Notice;
+	public void notice(ControlTransferObject cto, BaseModel model) {
+		lastAction = Action.NOTICE;
 		noticed.add(model);
-		action = action_;
-		assignHandler(event);
+		updateCTO(cto);
+		assignHandler();
+	}
+	
+	private void updateCTO(ControlTransferObject cto) {
+		if(cto instanceof FollowUpAction) {
+			cto.appendTo(this.cto);
+		} else {
+			this.cto = cto;
+		}
 	}
 
-	private void assignHandler(MouseEvent event) {
-		log.info("Doing " + action + " because of " + event.getButton() + "; have " + noticed + " noticed");
+	private void assignHandler() {
+		log.info("Doing " + cto.getAction() + " because of " + cto.getEvent().getButton() + "; have " + noticed + " noticed");
 		switch (state) {
 		case IDLE:
-			assignIfIDLE(event);
+			assignIfIDLE();
 			break;
 		case SPAWNING:
-			assignIfSPAWNING(event);
+			assignIfSPAWNING();
 			break;
 		case CONNECTING_FIRST, CONNECTING_SECOND:
-			assignIfConnecting(event);
+			assignIfConnecting();
 			break;
 		default:
 		}
 	}
 
-	private void assignIfIDLE(MouseEvent event) {
-		switch (action) {
+	private void assignIfIDLE() {
+		switch (cto.getAction()) {
 		case SUSPEND:
 			suspendEntity();
 			break;
@@ -105,7 +113,7 @@ public class GameController{
 			enableConnectingState();
 			break;
 		case DESPAWN:
-			despawnEntity(event);
+			despawnEntity();
 			break;
 		case RECIPE:
 			setRecipe();
@@ -118,10 +126,10 @@ public class GameController{
 		}
 	}
 
-	private void assignIfSPAWNING(MouseEvent event) {
-		switch (action) {
+	private void assignIfSPAWNING() {
+		switch (cto.getAction()) {
 		case SPAWN:
-			spawnEntity(event);
+			spawnEntity();
 			break;
 		case CANCEL:
 			returnToIDLE();
@@ -131,13 +139,13 @@ public class GameController{
 		}
 	}
 
-	private void assignIfConnecting(MouseEvent event) {
-		switch (action) {
+	private void assignIfConnecting() {
+		switch (cto.getAction()) {
 		case CONNECT_IN:
-			connectIn(event);
+			connectIn();
 			break;
 		case CONNECT_OUT:
-			connectOut(event);
+			connectOut();
 			break;
 		case CANCEL:
 			returnToIDLE();
@@ -148,9 +156,13 @@ public class GameController{
 	}
 
 	private void setRecipe() {
-		BaseModel model = noticed.remove();
-		//TODO migrate to dto for controller
-		log.error("set recipe");
+		var model = noticed.remove();
+		if(cto instanceof RecipeAction rcto && model instanceof IProducer producer) {
+			producer.setCurrentRecipe(rcto.getItem());
+		} else {
+			log.error(ILLEGAL_BUTTON_ARGUMENT, cto, model);
+			throw new IllegalArgumentException();
+		}
 	}
 	
 	private void returnToIDLE() {
@@ -162,32 +174,36 @@ public class GameController{
 		noticed.clear();
 	}
 
-	private void connectIn(MouseEvent event) {
+	private void connectIn() {
 		state = State.IDLE;
 		game.forEachEntity(w -> w.setConnectableState(ConnectableState.NO_POINTS));
-		try {
-			ConnectionOutPoint out = (ConnectionOutPoint) noticed.remove();
-			ConnectionInPoint in = (ConnectionInPoint) noticed.remove();
-			Spawner.spawnConnection(out, in, classPack);
-		} catch(Exception e) {
-			log.error("Spawn of [ " + classPack.toString() + " ] failed. " + "Already in normal state.", e);
-			//e.printStackTrace();
+		if(cto instanceof PackAction pcto) {
+			try {
+				ConnectionOutPoint out = (ConnectionOutPoint) noticed.remove();
+				ConnectionInPoint in = (ConnectionInPoint) noticed.remove();
+				Spawner.spawnConnection(out, in, pcto.getPack());
+			} catch(Exception e) {
+				log.error("Spawn of [ " + pcto.getPack().toString() + " ] failed. " + "Already in normal state.", e);
+			}
+		}else {
+			log.error(ILLEGAL_BUTTON_ARGUMENT, cto);
+			throw new IllegalArgumentException();
 		}
 	}
 
-	private void connectOut(MouseEvent event) {
+	private void connectOut() {
 		state = State.CONNECTING_SECOND;
 		game.forEachEntity(w -> w.setConnectableState(ConnectableState.IN_POINTS));
 	}
 
 	private void cancelOperation() {
-		if (lastAction == Action.Notice) {
+		if (lastAction == Action.NOTICE) {
 			noticed.removeLast();
 		}
 		log.info("ignoring " + noticed);
 	}
 	
-	private void despawnEntity(MouseEvent event) {
+	private void despawnEntity() {
 		if(noticed.remove() instanceof IConnectable model) {
 			view.removeOrphan(game.removeEntity(model));
 		} else { 
@@ -195,16 +211,21 @@ public class GameController{
 		}
 	}
 
-	private void spawnEntity(MouseEvent event) {
+	private void spawnEntity() {
 		if (state == State.SPAWNING) {
-			try {
-				Spawner.spawnEntity(shadow.getX(), shadow.getY(), classPack, this);
-			} catch (Exception e) {
-				log.error("Spawn of [ "  + classPack.toString() + " ] failed. " + "Returning to normal state.");
-				e.printStackTrace();
-			} finally {
-				state = State.IDLE;
-				disableShadow();
+			if(cto instanceof PackAction pcto) {
+				try {
+					Spawner.spawnEntity(shadow.getX(), shadow.getY(), pcto.getPack(), this);
+				} catch (Exception e) {
+					log.error("Spawn of [ "  + pcto.getPack().toString() + " ] failed. " + "Returning to normal state.");
+					e.printStackTrace();
+				} finally {
+					state = State.IDLE;
+					disableShadow();
+				}
+			}else {
+				log.error(ILLEGAL_BUTTON_ARGUMENT, cto);
+				throw new IllegalArgumentException();
 			}
 		}
 	}
@@ -229,8 +250,8 @@ public class GameController{
 
 	private void showInfo() {
 		BaseModel model = noticed.remove();
-		BindingController bController = new BindingController(this, model);
-		ConnectableInfo info = new ConnectableInfo(bController);
+		var bController = new BindingController(this, model);
+		var info = new ConnectableInfo(bController);
 		VBox currentInfo = view.getInfo();
 		if (currentInfo instanceof IModelInfo) {
 			((IModelInfo) currentInfo).disable();

--- a/src/main/java/com/hikari/hellofx/game/GameController.java
+++ b/src/main/java/com/hikari/hellofx/game/GameController.java
@@ -4,7 +4,6 @@ import java.util.ArrayDeque;
 
 import com.hikari.hellofx.base.BaseModel;
 import com.hikari.hellofx.base.IModelInfo;
-import com.hikari.hellofx.entity.view.ConnectableInfo;
 import com.hikari.hellofx.entity.BindingController;
 import com.hikari.hellofx.entity.IConnectable;
 import com.hikari.hellofx.entity.model.BasicEntityModel;
@@ -12,6 +11,7 @@ import com.hikari.hellofx.entity.model.ConnectableState;
 import com.hikari.hellofx.entity.model.ConnectionInPoint;
 import com.hikari.hellofx.entity.model.ConnectionOutPoint;
 import com.hikari.hellofx.entity.model.EntityShadow;
+import com.hikari.hellofx.entity.view.info.ConnectableInfo;
 import com.hikari.hellofx.game.classpack.ClassPack;
 import com.hikari.hellofx.game.view.GameField;
 import com.hikari.hellofx.game.view.GameView;
@@ -107,6 +107,9 @@ public class GameController{
 		case DESPAWN:
 			despawnEntity(event);
 			break;
+		case RECIPE:
+			setRecipe();
+			break;
 		case CANCEL:
 			returnToIDLE();
 			break;
@@ -144,11 +147,16 @@ public class GameController{
 		}
 	}
 
+	private void setRecipe() {
+		BaseModel model = noticed.remove();
+		//TODO migrate to dto for controller
+		log.error("set recipe");
+	}
+	
 	private void returnToIDLE() {
 		if (state == State.SPAWNING) {
 			disableShadow();
 		}
-		//TODO hide points of already checked
 		game.forEachEntity(w -> w.setConnectableState(ConnectableState.NO_POINTS));
 		state = State.IDLE;
 		noticed.clear();
@@ -180,8 +188,11 @@ public class GameController{
 	}
 	
 	private void despawnEntity(MouseEvent event) {
-		BaseModel model = noticed.remove();
-		((BasicEntityModel) model).despawn(); // TODO??? mb interface && handler?
+		if(noticed.remove() instanceof IConnectable model) {
+			view.removeOrphan(game.removeEntity(model));
+		} else { 
+			throw new IllegalArgumentException();
+		}
 	}
 
 	private void spawnEntity(MouseEvent event) {

--- a/src/main/java/com/hikari/hellofx/game/GameController.java
+++ b/src/main/java/com/hikari/hellofx/game/GameController.java
@@ -1,7 +1,6 @@
 package com.hikari.hellofx.game;
 
 import java.util.ArrayDeque;
-import java.util.List;
 
 import com.hikari.hellofx.base.BaseModel;
 import com.hikari.hellofx.base.IModelInfo;
@@ -208,8 +207,7 @@ public class GameController{
 	private void despawnEntity() {
 		if(noticed.remove() instanceof IConnectable model) {
 			view.removeOrphan(game.removeEntity(model));
-			List<BasicConnectionView> views = game.removeConnectionViews(model);
-			for(BasicConnectionView i : views) {
+			for(BasicConnectionView i : game.removeConnectionViews(model)) {
 				view.removeOrphan(i);
 			}
 		} else { 

--- a/src/main/java/com/hikari/hellofx/game/GameController.java
+++ b/src/main/java/com/hikari/hellofx/game/GameController.java
@@ -43,6 +43,7 @@ public class GameController{
 	private final GameView view;
 	private final EntityShadow shadow = new EntityShadow();
 	private final ArrayDeque<BaseModel> noticed = new ArrayDeque<>();
+	private ControlTransferObject previousCto = null;
 	private ControlTransferObject cto = null;
 
 	public GameController(GameView view) {
@@ -76,6 +77,7 @@ public class GameController{
 	}
 	
 	private void updateCTO(ControlTransferObject cto) {
+		previousCto = this.cto;
 		if(cto instanceof FollowUpAction) {
 			cto.appendTo(this.cto);
 		} else {
@@ -201,13 +203,14 @@ public class GameController{
 		if (lastAction == Action.NOTICE) {
 			noticed.removeLast();
 		}
+		cto = previousCto;
 		log.info("ignoring " + noticed);
 	}
 	
 	private void despawnEntity() {
 		if(noticed.remove() instanceof IConnectable model) {
 			view.removeOrphan(game.removeEntity(model));
-			for(BasicConnectionView i : game.removeConnectionViews(model)) {
+			for(BasicConnectionView i : game.removeConnections(model)) {
 				view.removeOrphan(i);
 			}
 		} else { 

--- a/src/main/java/com/hikari/hellofx/game/GameController.java
+++ b/src/main/java/com/hikari/hellofx/game/GameController.java
@@ -7,11 +7,11 @@ import com.hikari.hellofx.base.IModelInfo;
 import com.hikari.hellofx.entity.BindingController;
 import com.hikari.hellofx.entity.IConnectable;
 import com.hikari.hellofx.entity.IProducer;
-import com.hikari.hellofx.entity.model.BasicEntityModel;
 import com.hikari.hellofx.entity.model.ConnectableState;
-import com.hikari.hellofx.entity.model.ConnectionInPoint;
-import com.hikari.hellofx.entity.model.ConnectionOutPoint;
 import com.hikari.hellofx.entity.model.EntityShadow;
+import com.hikari.hellofx.entity.model.basic.BasicEntityModel;
+import com.hikari.hellofx.entity.model.cpoint.ConnectionInPoint;
+import com.hikari.hellofx.entity.model.cpoint.ConnectionOutPoint;
 import com.hikari.hellofx.entity.view.BasicConnectionView;
 import com.hikari.hellofx.entity.view.info.ConnectableInfo;
 import com.hikari.hellofx.game.control.ControlTransferObject;
@@ -45,10 +45,10 @@ public class GameController{
 	private final ArrayDeque<BaseModel> noticed = new ArrayDeque<>();
 	private ControlTransferObject cto = null;
 
-	public GameController(GameView view_) {
-		view = view_;
+	public GameController(GameView view) {
+		this.view = view;
 		Spawner.setGame(game);
-		Spawner.setView(view_);
+		Spawner.setView(view);
 	}
 
 	private void enableSPAWNINGState() {
@@ -262,7 +262,7 @@ public class GameController{
 		}
 		model.subscribe(info);
 		model.notifySubs();
-		view.showInfo((IConnectable) model, info);
+		view.showInfo(info);
 	}
 
 	public Object moveShadow(MouseEvent event) {

--- a/src/main/java/com/hikari/hellofx/game/GameController.java
+++ b/src/main/java/com/hikari/hellofx/game/GameController.java
@@ -1,6 +1,7 @@
 package com.hikari.hellofx.game;
 
 import java.util.ArrayDeque;
+import java.util.List;
 
 import com.hikari.hellofx.base.BaseModel;
 import com.hikari.hellofx.base.IModelInfo;
@@ -12,6 +13,7 @@ import com.hikari.hellofx.entity.model.ConnectableState;
 import com.hikari.hellofx.entity.model.ConnectionInPoint;
 import com.hikari.hellofx.entity.model.ConnectionOutPoint;
 import com.hikari.hellofx.entity.model.EntityShadow;
+import com.hikari.hellofx.entity.view.BasicConnectionView;
 import com.hikari.hellofx.entity.view.info.ConnectableInfo;
 import com.hikari.hellofx.game.control.ControlTransferObject;
 import com.hikari.hellofx.game.control.FollowUpAction;
@@ -206,6 +208,10 @@ public class GameController{
 	private void despawnEntity() {
 		if(noticed.remove() instanceof IConnectable model) {
 			view.removeOrphan(game.removeEntity(model));
+			List<BasicConnectionView> views = game.removeConnectionViews(model);
+			for(BasicConnectionView i : views) {
+				view.removeOrphan(i);
+			}
 		} else { 
 			throw new IllegalArgumentException();
 		}

--- a/src/main/java/com/hikari/hellofx/game/GameController.java
+++ b/src/main/java/com/hikari/hellofx/game/GameController.java
@@ -278,4 +278,8 @@ public class GameController{
 		game.getField().subscribe(gameField);
 
 	}
+
+	public void stopTheWorld() {
+		game.removeAll();
+	}
 }

--- a/src/main/java/com/hikari/hellofx/game/Spawner.java
+++ b/src/main/java/com/hikari/hellofx/game/Spawner.java
@@ -51,7 +51,7 @@ public class Spawner {
 			model.subscribe(spawned);
 			model.notifySubs();
 
-			game.addConnection((IConnection) model);
+			game.addConnection((IConnection) model, spawned);
 			view.showSpawned(spawned);
 			service.start();
 			log.info("connected");

--- a/src/main/java/com/hikari/hellofx/game/Spawner.java
+++ b/src/main/java/com/hikari/hellofx/game/Spawner.java
@@ -38,26 +38,19 @@ public class Spawner {
 			if(out.parentEquals(in)) {
 				throw new IllegalArgumentException("points have same parent");
 			}
-			log.info("spwn " + cpack.toString());
 
 			BaseModel model = cpack.getModel().getDeclaredConstructor(ConnectionOutPoint.class, ConnectionInPoint.class)
 					.newInstance(out, in);
-			log.info("subbed1");
 			BasicConnectionView spawned = cpack.getView()
 					.getDeclaredConstructor(ConnectionOutPoint.class, ConnectionInPoint.class).newInstance(out, in);
-			log.info("subbed2");
 			BaseService service = cpack.getService().getDeclaredConstructor(ISuspendable.class)
 					.newInstance((ISuspendable) model);
-			log.info("subbed3");
 			model.subscribe(spawned);
-			log.info("subbed4");
 			model.notifySubs();
-			log.info("subbed");
 			game.addConnection((IConnection) model, spawned, service);
-			log.info("added");
 			view.showSpawned(spawned);
 			service.start();
-			log.info("connected");
+			log.info("connected " + cpack.toString());
 		} else {
 			throw new IllegalArgumentException("wrong classpack");
 		}

--- a/src/main/java/com/hikari/hellofx/game/Spawner.java
+++ b/src/main/java/com/hikari/hellofx/game/Spawner.java
@@ -9,8 +9,8 @@ import com.hikari.hellofx.entity.IConnectable;
 import com.hikari.hellofx.entity.IConnection;
 import com.hikari.hellofx.entity.IServiceNotifier;
 import com.hikari.hellofx.entity.ISuspendable;
-import com.hikari.hellofx.entity.model.ConnectionInPoint;
-import com.hikari.hellofx.entity.model.ConnectionOutPoint;
+import com.hikari.hellofx.entity.model.cpoint.ConnectionInPoint;
+import com.hikari.hellofx.entity.model.cpoint.ConnectionOutPoint;
 import com.hikari.hellofx.entity.view.BasicConnectionView;
 import com.hikari.hellofx.entity.view.BasicEntityView;
 import com.hikari.hellofx.game.control.ClassPack;
@@ -31,7 +31,6 @@ public class Spawner {
 	private Spawner() {
 	}
 
-	// TODO register threads somehow
 	public static void spawnConnection(ConnectionOutPoint out, ConnectionInPoint in, ClassPack pack)
 			throws InstantiationException, IllegalAccessException, IllegalArgumentException, InvocationTargetException,
 			NoSuchMethodException, SecurityException {

--- a/src/main/java/com/hikari/hellofx/game/Spawner.java
+++ b/src/main/java/com/hikari/hellofx/game/Spawner.java
@@ -7,7 +7,7 @@ import com.hikari.hellofx.base.BaseService;
 import com.hikari.hellofx.entity.BindingController;
 import com.hikari.hellofx.entity.IConnectable;
 import com.hikari.hellofx.entity.IConnection;
-import com.hikari.hellofx.entity.IServiceable;
+import com.hikari.hellofx.entity.IServiceNotifier;
 import com.hikari.hellofx.entity.ISuspendable;
 import com.hikari.hellofx.entity.model.ConnectionInPoint;
 import com.hikari.hellofx.entity.model.ConnectionOutPoint;
@@ -71,7 +71,7 @@ public class Spawner {
 					.newInstance((ISuspendable) model);
 
 			model.subscribe(spawned);
-			((IServiceable) model).connectService(service);
+			((IServiceNotifier) model).connectService(service);
 			view.showSpawned(spawned);
 			game.addEntity((IConnectable) model);
 			service.start();

--- a/src/main/java/com/hikari/hellofx/game/Spawner.java
+++ b/src/main/java/com/hikari/hellofx/game/Spawner.java
@@ -53,7 +53,7 @@ public class Spawner {
 			log.info("subbed4");
 			model.notifySubs();
 			log.info("subbed");
-			game.addConnection((IConnection) model, spawned);
+			game.addConnection((IConnection) model, spawned, service);
 			log.info("added");
 			view.showSpawned(spawned);
 			service.start();

--- a/src/main/java/com/hikari/hellofx/game/Spawner.java
+++ b/src/main/java/com/hikari/hellofx/game/Spawner.java
@@ -13,9 +13,9 @@ import com.hikari.hellofx.entity.model.ConnectionInPoint;
 import com.hikari.hellofx.entity.model.ConnectionOutPoint;
 import com.hikari.hellofx.entity.view.BasicConnectionView;
 import com.hikari.hellofx.entity.view.BasicEntityView;
-import com.hikari.hellofx.game.classpack.ClassPack;
-import com.hikari.hellofx.game.classpack.ConnectionClassPack;
-import com.hikari.hellofx.game.classpack.EntityClassPack;
+import com.hikari.hellofx.game.control.ClassPack;
+import com.hikari.hellofx.game.control.ConnectionClassPack;
+import com.hikari.hellofx.game.control.EntityClassPack;
 import com.hikari.hellofx.game.view.GameView;
 
 import lombok.Setter;

--- a/src/main/java/com/hikari/hellofx/game/Spawner.java
+++ b/src/main/java/com/hikari/hellofx/game/Spawner.java
@@ -27,9 +27,11 @@ public class Spawner {
 	private static Game game;
 	@Setter
 	private static GameView view;
+	
+	private Spawner() {
+	}
 
 	// TODO register threads somehow
-	// TODO ban self-connection
 	public static void spawnConnection(ConnectionOutPoint out, ConnectionInPoint in, ClassPack pack)
 			throws InstantiationException, IllegalAccessException, IllegalArgumentException, InvocationTargetException,
 			NoSuchMethodException, SecurityException {
@@ -73,7 +75,7 @@ public class Spawner {
 			model.subscribe(spawned);
 			((IServiceNotifier) model).connectService(service);
 			view.showSpawned(spawned);
-			game.addEntity((IConnectable) model);
+			game.addEntity((IConnectable) model, spawned, service);
 			service.start();
 		} else {
 			throw new IllegalArgumentException("wrong classpack");

--- a/src/main/java/com/hikari/hellofx/game/Spawner.java
+++ b/src/main/java/com/hikari/hellofx/game/Spawner.java
@@ -42,15 +42,19 @@ public class Spawner {
 
 			BaseModel model = cpack.getModel().getDeclaredConstructor(ConnectionOutPoint.class, ConnectionInPoint.class)
 					.newInstance(out, in);
+			log.info("subbed1");
 			BasicConnectionView spawned = cpack.getView()
 					.getDeclaredConstructor(ConnectionOutPoint.class, ConnectionInPoint.class).newInstance(out, in);
+			log.info("subbed2");
 			BaseService service = cpack.getService().getDeclaredConstructor(ISuspendable.class)
 					.newInstance((ISuspendable) model);
-
+			log.info("subbed3");
 			model.subscribe(spawned);
+			log.info("subbed4");
 			model.notifySubs();
-
+			log.info("subbed");
 			game.addConnection((IConnection) model, spawned);
+			log.info("added");
 			view.showSpawned(spawned);
 			service.start();
 			log.info("connected");

--- a/src/main/java/com/hikari/hellofx/game/classpack/EntityClassPack.java
+++ b/src/main/java/com/hikari/hellofx/game/classpack/EntityClassPack.java
@@ -6,16 +6,19 @@ import com.hikari.hellofx.entity.view.BasicEntityView;
 import com.hikari.hellofx.entity.view.AssemblerView;
 import com.hikari.hellofx.entity.view.ConstructorView;
 import com.hikari.hellofx.entity.view.MinerView;
+import com.hikari.hellofx.entity.view.MergerView;
 import com.hikari.hellofx.entity.view.SplitterView;
 import com.hikari.hellofx.entity.view.StorageView;
 import com.hikari.hellofx.entity.model.AssemblerModel;
 import com.hikari.hellofx.entity.model.ConstructorModel;
 import com.hikari.hellofx.entity.model.MinerModel;
+import com.hikari.hellofx.entity.model.MergerModel;
 import com.hikari.hellofx.entity.model.SplitterModel;
 import com.hikari.hellofx.entity.model.StorageModel;
 import com.hikari.hellofx.entity.service.AssemblerService;
 import com.hikari.hellofx.entity.service.ConstructorService;
 import com.hikari.hellofx.entity.service.MinerService;
+import com.hikari.hellofx.entity.service.MergerService;
 import com.hikari.hellofx.entity.service.SplitterService;
 import com.hikari.hellofx.entity.service.StorageService;
 
@@ -28,6 +31,7 @@ public enum EntityClassPack implements ClassPack{
 	CONSTRUCTOR(ConstructorModel.class, ConstructorView.class, ConstructorService.class),
 	MINER(MinerModel.class, MinerView.class, MinerService.class),
 	SPLITTER(SplitterModel.class, SplitterView.class, SplitterService.class),
+	MERGER(MergerModel.class, MergerView.class, MergerService.class),
 	STORAGE(StorageModel.class, StorageView.class, StorageService.class);
 	
 	@Getter

--- a/src/main/java/com/hikari/hellofx/game/control/BareAction.java
+++ b/src/main/java/com/hikari/hellofx/game/control/BareAction.java
@@ -1,0 +1,25 @@
+package com.hikari.hellofx.game.control;
+
+import com.hikari.hellofx.game.GameAction;
+
+import javafx.scene.input.MouseEvent;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+public class BareAction implements ControlTransferObject {
+	@Getter
+	private GameAction action;
+	@Getter
+	MouseEvent event;
+	
+	@Override
+	public void appendTo(ControlTransferObject cto) {
+		//reasons in FollowUpAction
+		((BareAction)cto).updateWith(this);
+	}
+	private void updateWith(ControlTransferObject cto) {
+		action = cto.getAction();
+		event = cto.getEvent();
+	}
+}

--- a/src/main/java/com/hikari/hellofx/game/control/ClassPack.java
+++ b/src/main/java/com/hikari/hellofx/game/control/ClassPack.java
@@ -1,11 +1,11 @@
-package com.hikari.hellofx.game.classpack;
+package com.hikari.hellofx.game.control;
 
 import com.hikari.hellofx.base.BaseModel;
 import com.hikari.hellofx.base.BaseService;
 
 import javafx.scene.layout.Pane;
 
-public interface ClassPack {
+public interface ClassPack{
 	public Class<? extends BaseModel> getModel();
 	public Class<? extends BaseService> getService();
 	public Class<? extends Pane> getView();

--- a/src/main/java/com/hikari/hellofx/game/control/ConnectionClassPack.java
+++ b/src/main/java/com/hikari/hellofx/game/control/ConnectionClassPack.java
@@ -1,4 +1,4 @@
-package com.hikari.hellofx.game.classpack;
+package com.hikari.hellofx.game.control;
 
 import com.hikari.hellofx.base.BaseModel;
 import com.hikari.hellofx.base.BaseService;

--- a/src/main/java/com/hikari/hellofx/game/control/ConnectionClassPack.java
+++ b/src/main/java/com/hikari/hellofx/game/control/ConnectionClassPack.java
@@ -4,10 +4,10 @@ import com.hikari.hellofx.base.BaseModel;
 import com.hikari.hellofx.base.BaseService;
 import com.hikari.hellofx.entity.model.conveyor.Conveyor;
 import com.hikari.hellofx.entity.view.conveyor.ConveyorView;
-import com.hikari.hellofx.entity.service.ConveyorService;
+import com.hikari.hellofx.entity.service.connection.BeltService;
+import com.hikari.hellofx.entity.service.connection.ConveyorService;
 import com.hikari.hellofx.entity.model.belt.Belt;
 import com.hikari.hellofx.entity.view.belt.BeltView;
-import com.hikari.hellofx.entity.service.BeltService;
 import com.hikari.hellofx.entity.view.BasicConnectionView;
 
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/hikari/hellofx/game/control/ControlTransferObject.java
+++ b/src/main/java/com/hikari/hellofx/game/control/ControlTransferObject.java
@@ -1,0 +1,11 @@
+package com.hikari.hellofx.game.control;
+
+import com.hikari.hellofx.game.GameAction;
+
+import javafx.scene.input.MouseEvent;
+
+public interface ControlTransferObject {
+	public GameAction getAction();
+	public MouseEvent getEvent();
+	public void appendTo(ControlTransferObject cto);
+}

--- a/src/main/java/com/hikari/hellofx/game/control/EntityClassPack.java
+++ b/src/main/java/com/hikari/hellofx/game/control/EntityClassPack.java
@@ -1,4 +1,4 @@
-package com.hikari.hellofx.game.classpack;
+package com.hikari.hellofx.game.control;
 
 import com.hikari.hellofx.base.BaseModel;
 import com.hikari.hellofx.base.BaseService;

--- a/src/main/java/com/hikari/hellofx/game/control/FollowUpAction.java
+++ b/src/main/java/com/hikari/hellofx/game/control/FollowUpAction.java
@@ -1,0 +1,18 @@
+package com.hikari.hellofx.game.control;
+
+import com.hikari.hellofx.game.GameAction;
+
+import javafx.scene.input.MouseEvent;
+
+/*
+ * for action that has nbot much info by itself
+ * but relies on previous action
+ * p.e. enter/finish spawning
+ */
+public class FollowUpAction extends BareAction{
+
+	public FollowUpAction(GameAction action, MouseEvent event) {
+		super(action, event);
+	}
+
+}

--- a/src/main/java/com/hikari/hellofx/game/control/PackAction.java
+++ b/src/main/java/com/hikari/hellofx/game/control/PackAction.java
@@ -1,0 +1,15 @@
+package com.hikari.hellofx.game.control;
+
+import com.hikari.hellofx.game.GameAction;
+
+import javafx.scene.input.MouseEvent;
+import lombok.Getter;
+
+public class PackAction extends BareAction{
+	@Getter
+	private ClassPack pack;
+	public PackAction(GameAction action, MouseEvent event, ClassPack pack) {
+		super(action, event);
+		this.pack = pack;
+	}
+}

--- a/src/main/java/com/hikari/hellofx/game/control/RecipeAction.java
+++ b/src/main/java/com/hikari/hellofx/game/control/RecipeAction.java
@@ -1,0 +1,16 @@
+package com.hikari.hellofx.game.control;
+
+import com.hikari.hellofx.entity.Items;
+import com.hikari.hellofx.game.GameAction;
+
+import javafx.scene.input.MouseEvent;
+import lombok.Getter;
+
+public class RecipeAction extends BareAction{
+	@Getter
+	private Items item;
+	public RecipeAction(GameAction action, MouseEvent event, Items item) {
+		super(action, event);
+		this.item = item;
+	}
+}

--- a/src/main/java/com/hikari/hellofx/game/control/RecipeAction.java
+++ b/src/main/java/com/hikari/hellofx/game/control/RecipeAction.java
@@ -1,6 +1,6 @@
 package com.hikari.hellofx.game.control;
 
-import com.hikari.hellofx.entity.Items;
+import com.hikari.hellofx.entity.Item;
 import com.hikari.hellofx.game.GameAction;
 
 import javafx.scene.input.MouseEvent;
@@ -8,8 +8,8 @@ import lombok.Getter;
 
 public class RecipeAction extends BareAction{
 	@Getter
-	private Items item;
-	public RecipeAction(GameAction action, MouseEvent event, Items item) {
+	private Item item;
+	public RecipeAction(GameAction action, MouseEvent event, Item item) {
 		super(action, event);
 		this.item = item;
 	}

--- a/src/main/java/com/hikari/hellofx/game/view/BottomMenu.java
+++ b/src/main/java/com/hikari/hellofx/game/view/BottomMenu.java
@@ -4,6 +4,7 @@ import com.hikari.hellofx.SceneClass;
 import com.hikari.hellofx.SceneController;
 import com.hikari.hellofx.entity.view.AssemblerView;
 import com.hikari.hellofx.entity.view.ConstructorView;
+import com.hikari.hellofx.entity.view.MergerView;
 import com.hikari.hellofx.entity.view.MinerView;
 import com.hikari.hellofx.entity.view.SplitterView;
 import com.hikari.hellofx.entity.view.StorageView;
@@ -24,6 +25,7 @@ public class BottomMenu extends HBox {
 		add(new SpawnButton(gcontroller, "Assembler", EntityClassPack.ASSEMBLER, AssemblerView.getColor()));
 		add(new SpawnButton(gcontroller, "Storage", EntityClassPack.STORAGE, StorageView.getColor()));
 		add(new SpawnButton(gcontroller, "Splitter", EntityClassPack.SPLITTER, SplitterView.getColor()));
+		add(new SpawnButton(gcontroller, "Merger", EntityClassPack.MERGER, MergerView.getColor()));
 		add(new ConnectionButton(gcontroller, "Conveyor", ConnectionClassPack.CONVEYOR));
 		add(new ConnectionButton(gcontroller, "Belt", ConnectionClassPack.BELT));
 		add(new NavButton(controller, "Main menu", SceneClass.MENU));

--- a/src/main/java/com/hikari/hellofx/game/view/BottomMenu.java
+++ b/src/main/java/com/hikari/hellofx/game/view/BottomMenu.java
@@ -9,8 +9,8 @@ import com.hikari.hellofx.entity.view.MinerView;
 import com.hikari.hellofx.entity.view.SplitterView;
 import com.hikari.hellofx.entity.view.StorageView;
 import com.hikari.hellofx.game.GameController;
-import com.hikari.hellofx.game.classpack.ConnectionClassPack;
-import com.hikari.hellofx.game.classpack.EntityClassPack;
+import com.hikari.hellofx.game.control.ConnectionClassPack;
+import com.hikari.hellofx.game.control.EntityClassPack;
 
 import javafx.scene.Node;
 import javafx.scene.layout.HBox;

--- a/src/main/java/com/hikari/hellofx/game/view/CancelButton.java
+++ b/src/main/java/com/hikari/hellofx/game/view/CancelButton.java
@@ -2,12 +2,13 @@ package com.hikari.hellofx.game.view;
 
 import com.hikari.hellofx.game.GameAction;
 import com.hikari.hellofx.game.GameController;
+import com.hikari.hellofx.game.control.BareAction;
 
 import javafx.scene.control.Button;
 
-public class CancelButton extends Button{
-	public CancelButton(GameController gcontroller, String label){
+public class CancelButton extends Button {
+	public CancelButton(GameController gcontroller, String label) {
 		super(label);
-		setOnMouseClicked((event) -> gcontroller.act(event, GameAction.CANCEL));
+		setOnMouseClicked((event) -> gcontroller.act(new BareAction(GameAction.CANCEL, event)));
 	}
 }

--- a/src/main/java/com/hikari/hellofx/game/view/CancelButton.java
+++ b/src/main/java/com/hikari/hellofx/game/view/CancelButton.java
@@ -9,6 +9,6 @@ import javafx.scene.control.Button;
 public class CancelButton extends Button {
 	public CancelButton(GameController gcontroller, String label) {
 		super(label);
-		setOnMouseClicked((event) -> gcontroller.act(new BareAction(GameAction.CANCEL, event)));
+		setOnMouseClicked(event -> gcontroller.act(new BareAction(GameAction.CANCEL, event)));
 	}
 }

--- a/src/main/java/com/hikari/hellofx/game/view/ConnectionButton.java
+++ b/src/main/java/com/hikari/hellofx/game/view/ConnectionButton.java
@@ -2,14 +2,14 @@ package com.hikari.hellofx.game.view;
 
 import com.hikari.hellofx.game.GameAction;
 import com.hikari.hellofx.game.GameController;
-import com.hikari.hellofx.game.classpack.ConnectionClassPack;
+import com.hikari.hellofx.game.control.ConnectionClassPack;
+import com.hikari.hellofx.game.control.PackAction;
 
 import javafx.scene.control.Button;
 
-public class ConnectionButton extends Button{
-	public ConnectionButton(GameController gcontroller, String label,
-			ConnectionClassPack classPack){
+public class ConnectionButton extends Button {
+	public ConnectionButton(GameController gcontroller, String label, ConnectionClassPack classPack) {
 		super(label);
-		setOnMouseClicked((event) -> gcontroller.act(event, GameAction.ENTER_CONNECT, classPack));
+		setOnMouseClicked(event -> gcontroller.act(new PackAction(GameAction.ENTER_CONNECT, event, classPack)));
 	}
 }

--- a/src/main/java/com/hikari/hellofx/game/view/ExitButton.java
+++ b/src/main/java/com/hikari/hellofx/game/view/ExitButton.java
@@ -1,13 +1,12 @@
 package com.hikari.hellofx.game.view;
 
-import com.hikari.hellofx.SceneClass;
 import com.hikari.hellofx.SceneController;
 
 import javafx.scene.control.Button;
 
 public class ExitButton extends Button{
-	public ExitButton(SceneController controller, String label, SceneClass scene) {
+	public ExitButton(SceneController controller, String label) {
 		super(label);
-		super.setOnAction(event -> controller.changeCurrentScene(scene));
+		super.setOnAction(event -> controller.exit());
 	}
 }

--- a/src/main/java/com/hikari/hellofx/game/view/ExitButton.java
+++ b/src/main/java/com/hikari/hellofx/game/view/ExitButton.java
@@ -1,0 +1,13 @@
+package com.hikari.hellofx.game.view;
+
+import com.hikari.hellofx.SceneClass;
+import com.hikari.hellofx.SceneController;
+
+import javafx.scene.control.Button;
+
+public class ExitButton extends Button{
+	public ExitButton(SceneController controller, String label, SceneClass scene) {
+		super(label);
+		super.setOnAction(event -> controller.changeCurrentScene(scene));
+	}
+}

--- a/src/main/java/com/hikari/hellofx/game/view/GameField.java
+++ b/src/main/java/com/hikari/hellofx/game/view/GameField.java
@@ -22,8 +22,8 @@ public class GameField extends Pane implements IModelSubscriber {
 		}
 	};
 
-	public GameField(GameController gcontroller_) {
-		gcontroller = gcontroller_;
+	public GameField(GameController gcontroller) {
+		this.gcontroller = gcontroller;
 		setPrefSize(640, 480);
 		field = new Rectangle(0, 0, 640, 480);
 		field.setFill(Color.GAINSBORO);

--- a/src/main/java/com/hikari/hellofx/game/view/GameField.java
+++ b/src/main/java/com/hikari/hellofx/game/view/GameField.java
@@ -13,6 +13,8 @@ import javafx.scene.paint.Color;
 import javafx.scene.shape.Rectangle;
 
 public class GameField extends Pane implements IModelSubscriber {
+	private static final double WIDTH = 1200;
+	private static final double HEIGHT = 800;
 	private final Rectangle field;
 	private final GameController gcontroller;
 	private final EventHandler<MouseEvent> handler = new EventHandler<MouseEvent>() {
@@ -24,8 +26,8 @@ public class GameField extends Pane implements IModelSubscriber {
 
 	public GameField(GameController gcontroller) {
 		this.gcontroller = gcontroller;
-		setPrefSize(640, 480);
-		field = new Rectangle(0, 0, 640, 480);
+		setPrefSize(WIDTH, HEIGHT);
+		field = new Rectangle(0, 0, WIDTH, HEIGHT);
 		field.setFill(Color.GAINSBORO);
 		add(field);
 	}

--- a/src/main/java/com/hikari/hellofx/game/view/GameView.java
+++ b/src/main/java/com/hikari/hellofx/game/view/GameView.java
@@ -1,10 +1,10 @@
 package com.hikari.hellofx.game.view;
 
 import com.hikari.hellofx.SceneController;
-import com.hikari.hellofx.entity.view.ConnectableInfo;
 import com.hikari.hellofx.entity.IConnectable;
 import com.hikari.hellofx.entity.model.EntityShadow;
 import com.hikari.hellofx.entity.view.EntityShadowView;
+import com.hikari.hellofx.entity.view.info.ConnectableInfo;
 import com.hikari.hellofx.game.GameController;
 
 import javafx.scene.Node;
@@ -37,6 +37,10 @@ public class GameView extends GridPane{
 	
 	public void showSpawned(Node spawned) {
 		gameField.add(spawned);
+	}
+	
+	public void removeOrphan(Node orphanedNode) {
+		gameField.remove(orphanedNode);
 	}
 	
 	public VBox getInfo() {

--- a/src/main/java/com/hikari/hellofx/game/view/GameView.java
+++ b/src/main/java/com/hikari/hellofx/game/view/GameView.java
@@ -70,4 +70,8 @@ public class GameView extends GridPane{
 		gameField.remove(shadowView);
 		shadowView.disable();
 	}
+	
+	public void stopTheWorld() {
+		gController.stopTheWorld();
+	}
 }

--- a/src/main/java/com/hikari/hellofx/game/view/GameView.java
+++ b/src/main/java/com/hikari/hellofx/game/view/GameView.java
@@ -1,7 +1,6 @@
 package com.hikari.hellofx.game.view;
 
 import com.hikari.hellofx.SceneController;
-import com.hikari.hellofx.entity.IConnectable;
 import com.hikari.hellofx.entity.model.EntityShadow;
 import com.hikari.hellofx.entity.view.EntityShadowView;
 import com.hikari.hellofx.entity.view.info.ConnectableInfo;
@@ -47,7 +46,7 @@ public class GameView extends GridPane{
 		return infoMenu;
 	}
 	
-	public void showInfo(IConnectable model, ConnectableInfo info) {
+	public void showInfo(ConnectableInfo info) {
 		getChildren().remove(infoMenu);
 		infoMenu = info;
 		add(infoMenu, 1, 0);

--- a/src/main/java/com/hikari/hellofx/game/view/NavButton.java
+++ b/src/main/java/com/hikari/hellofx/game/view/NavButton.java
@@ -8,6 +8,6 @@ import javafx.scene.control.Button;
 public class NavButton extends Button{
 	public NavButton(SceneController controller, String label, SceneClass scene) {
 		super(label);
-		super.setOnAction((event) -> controller.changeCurrentScene(scene));
+		super.setOnAction(event -> controller.changeCurrentScene(scene));
 	}
 }

--- a/src/main/java/com/hikari/hellofx/game/view/SpawnButton.java
+++ b/src/main/java/com/hikari/hellofx/game/view/SpawnButton.java
@@ -2,7 +2,8 @@ package com.hikari.hellofx.game.view;
 
 import com.hikari.hellofx.game.GameAction;
 import com.hikari.hellofx.game.GameController;
-import com.hikari.hellofx.game.classpack.EntityClassPack;
+import com.hikari.hellofx.game.control.EntityClassPack;
+import com.hikari.hellofx.game.control.PackAction;
 
 import javafx.geometry.Insets;
 import javafx.scene.control.Button;
@@ -20,7 +21,7 @@ public class SpawnButton extends Button {
 		super(label);
 		setBackground(new Background(new BackgroundFill(color, CornerRadii.EMPTY, Insets.EMPTY)));
 		setBorder(new Border(new BorderStroke(color.darker(), BorderStrokeStyle.SOLID, null, null)));
-		setOnMouseClicked((event) -> gcontroller.act(event, GameAction.ENTER_SPAWN, entityClassPack));
+		setOnMouseClicked(event -> gcontroller.act(new PackAction(GameAction.ENTER_SPAWN, event, entityClassPack)));
 		
 	}
 }

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -2,7 +2,7 @@
 <Configuration status="WARN">
 	<Appenders>
         <Console name="Console" target="SYSTEM_OUT">
-          <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+          <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{2} - %msg%n"/>
         </Console>
       </Appenders>
       <Loggers>


### PR DESCRIPTION
changelog:
 * почитал про Data Transfer Object, поленился устраивать у себя - но зато переписал основной контроллер на CTO aka Control Transfer Object
 * рецепты, айтемы, красивые кружочки - хотя и с заглушечной реализацией "выбрасывать все что пришло если не подходит под рецепт"
   * привет из майнкрафта - догадываться до рецептов придется самому (ну или в коде посмотреть)
 * рабочий выход по кнопке (да как выйти из этого вима?) )
 * удаление entity'ей, которое действительно удаляет их, останавливает сервис, тыкает во все коннекшны и их тоже останавливает
   * хотя здесь очередная заглушечная реализация - в Factorio/Satisfactory конвейер, подключенный только одним концом вполне продолжает работать и что-то куда-то везти, а в моем случае он просто скидывает все содержимое и умирает. Но механика не позволяет подключить ноду к конвейеру (конвейеры создаются между двумя поинтами на нодах), поэтому не скидывать не имеет смысла, это ближе к обрыву проводов в вышеуказанных играх
 * упростил логику splitter/merger за несколько итераций - KISS
 * немножко QoL вроде автовыбора первого рецепта при включении entity
 * InterruptedExceprions больше не игнорируются

Остался еще ворох незначительных TODO в коде, и идея сделать сохранения с сериализацией (через Externalizable, наверное?)- надо будет перенести в отдельный файлик.
